### PR TITLE
feat: ヘルスチェック用エンドポイントを追加

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -46,6 +46,8 @@ export function createApp(engine: WorldEngine, options: AppOptions) {
   registerAgentServerEventRoutes(app, engine);
   registerUiRoutes(app, engine, { adminKey: options.adminKey });
 
+  app.get('/health', (c) => c.json({ status: 'ok' }));
+
   app.get(
     '/ws',
     adminAuth(options.adminKey),


### PR DESCRIPTION
## Summary
- `/health` エンドポイントを追加し、`{ status: 'ok' }` を返すようにした
- Docker Compose 等でのヘルスチェックに利用可能

## Test plan
- [x] `GET /health` で `200 OK` と `{ "status": "ok" }` が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)