### PR TITLE
fix: Docker コンテナにフォントを追加しマップ画像のテキスト描画を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@
 # (or via: npm run docker:prepare). This directory contains production-ready
 # node_modules and compiled dist output.
 FROM node:24-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fontconfig \
+    fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## Summary
- `node:24-slim` にはフォントおよび `fontconfig` が含まれないため、`@resvg/resvg-js` がテキストを描画できず `#world-status` のマップ画像でノードIDやラベルが表示されなかった
- Dockerfile に `fontconfig` と `fonts-noto-cjk` を追加して修正

## Test plan
- [x] Docker コンテナ内でマップ画像を生成し、ノードIDと日本語ラベルの両方が表示されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)