### PR TITLE
docs: update English README to match restructured ja README

### DIFF
--- a/karakuri-world-ui/README.ja.md
+++ b/karakuri-world-ui/README.ja.md
@@ -1,203 +1,159 @@
 # karakuri-world-ui
 
-## 観戦 UI の開発・ビルド環境
+観戦用 UI。Vite/React SPA（Cloudflare Pages）+ Cloudflare Worker（履歴 API・スナップショット配信）の 2 層構成。
 
-この Vite アプリは fail-fast 方針で、必要なブラウザ側の環境変数が揃っていない場合は `npm run dev` / `npm run build` が即座に停止する。
+## ローカル開発
 
-`karakuri-world-ui/.env.local`（または他の Vite env ファイル）を作成する：
+`.env.local` を作成してから起動する：
 
 ```bash
-VITE_SNAPSHOT_URL=https://snapshots.example.com/snapshot/latest.json
+VITE_SNAPSHOT_URL=https://snapshot.example.com/snapshot/latest.json
 VITE_AUTH_MODE=public
-VITE_API_BASE_URL=https://history.example.com/api/history
-VITE_PHASE3_EFFECTS_ENABLED=false
-VITE_PHASE3_EFFECT_RAIN_ENABLED=false
-VITE_PHASE3_EFFECT_SNOW_ENABLED=false
-VITE_PHASE3_EFFECT_FOG_ENABLED=false
-VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED=false
-VITE_PHASE3_EFFECT_MOTION_ENABLED=false
-VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED=false
+VITE_API_BASE_URL=https://your-worker.workers.dev/api/history
 ```
-
-### 必須項目
-
-- `VITE_SNAPSHOT_URL`: ブラウザから直接 fetch できるスナップショット公開 URL の絶対パス。plan12 以降は R2 カスタムドメイン配下のオブジェクト URL を指す。ブラウザバンドルに同梱される値なので、`http` / `https` のみ、かつ認証情報・クエリ・フラグメントを含めてはならない。`/api/snapshot` を指してはならず、ブラウザは常に R2 カスタムドメイン配下のオブジェクト URL を直接ポーリングする。
-- `VITE_AUTH_MODE`: `public` または `access` のいずれか。
-- `VITE_API_BASE_URL`: Worker history API の絶対 URL。必ず `/api/history` までを含む完全な URL とし、Worker オリジンだけ / 親パス `/api` だけでは不可。こちらもブラウザ公開値のため、認証情報・クエリ・フラグメントは禁止。
-- `VITE_PHASE3_EFFECTS_ENABLED`（任意）: `true` / `false`。既定値 `false`。意図的に Phase 3 エフェクトを検証するとき以外は OFF のままにする。
-- `VITE_PHASE3_EFFECT_RAIN_ENABLED` / `VITE_PHASE3_EFFECT_SNOW_ENABLED` / `VITE_PHASE3_EFFECT_FOG_ENABLED` / `VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED`（任意）: 個別エフェクトの rollout フラグ。既定値はすべて `false` で、`VITE_PHASE3_EFFECTS_ENABLED=true` のときにのみ有効。rain / snow / fog / day-night を Phase 3 基盤を残したまま個別にロールバック可能。
-- `VITE_PHASE3_EFFECT_MOTION_ENABLED` / `VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED`（任意）: 移動補間と `current_activity.emoji` ベースの軽量パーティクルの rollout フラグ。既定値 `false`、かつ `VITE_PHASE3_EFFECTS_ENABLED=true` のときのみ有効。段階 rollout / ロールバック時は Phase 1 の静的ノード描画がフォールバックとして残る。
-
-### ローカル検証
 
 ```bash
 cd karakuri-world-ui
+npm install
 npm run dev
-npm run build
-npm run test:phase1-acceptance
 ```
 
-## Phase 1 受入ゲート
+必須環境変数が欠けていると `npm run dev` / `npm run build` は即座に停止する（fail-fast）。
 
-`npm run test:phase1-acceptance` は観戦 UI の Phase 1 振る舞いに絞った受入ゲート。Unit 28 以降の配信経路転換は Unit 29+ で整理されているが、実務的な UI の go/no-go チェックとしてこのコマンドを使う。
+### 環境変数一覧
 
-自動ゲートが保証する項目：
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `VITE_SNAPSHOT_URL` | ✓ | R2 カスタムドメインのスナップショット URL（`/api/snapshot` は不可） |
+| `VITE_AUTH_MODE` | ✓ | `public` または `access` |
+| `VITE_API_BASE_URL` | ✓ | Worker の `/api/history` までの完全な URL |
+| `VITE_PHASE3_EFFECTS_ENABLED` | - | エフェクト機能全体の ON/OFF（既定 `false`） |
+| `VITE_PHASE3_EFFECT_RAIN_ENABLED` など | - | 個別エフェクトフラグ（既定 `false`） |
 
-- デスクトップ / モバイル初期シェルが同一 map host を共有して描画される
-- 100 エージェントのスナップショット反映が Phase 1 の 15 秒予算内に収まる
-- `/api/history` が空 or 劣化していても、選択中エージェント詳細の一貫性が保たれる
-- `/api/history?agent_id=...&limit=20` が取得できる場合は会話ログ展開が加算的に動く
-- 静穏期の鮮度（`generated_at` の更新で 60 秒閾値に達する前に stale 化しないこと）
-- **Unit 29/32 との整合**: sub-minute 可能な publisher トリガで駆動される定周期スナップショット発行＋直接 R2 ポーリングが、15 秒予算を守ること
+## デプロイ手順
 
-フルスイートは `npm test`、Phase 1 ゲートのみを回すなら `npm run test:phase1-acceptance`。
-
-## Phase 2 認証モード別デプロイガイド
-
-1 つのデプロイで選べる認証モードは `AUTH_MODE=public` または `AUTH_MODE=access` のいずれか 1 つ。Pages / Worker `/api/history` / R2 `snapshot_url` のすべてが同じモードで構成されたときのみデプロイ成立。
-
-- `AUTH_MODE=public`: Pages・Worker `/api/history`・R2 カスタムドメインがすべて公開。
-- `AUTH_MODE=access`: Pages・Worker `/api/history`・R2 カスタムドメインがすべて Cloudflare Access で保護され、ブラウザは `snapshot_url` / `/api/history` 双方を `credentials: 'include'` で fetch する。
-- Pages と Worker `/api/history` がクロスオリジンの場合、Worker の `HISTORY_CORS_ALLOWED_ORIGINS` に許可する Pages オリジンをカンマ区切りで指定する（例: `https://ui.example.com,https://preview-ui.example.com`）。Worker は設定済みオリジンのみエコーし、`AUTH_MODE=access` では `Access-Control-Allow-Credentials: true` も返すため `*` では代替不可。
-
-1 デプロイ内でモードを混在させないこと。また `AUTH_MODE=access` の前提が満たされない場合でも Worker/Pages によるスナップショットプロキシをフォールバックとして追加してはならない。Access Cookie の共有 / 事前 seed が確約できない場合は `/api` 経由で中継せず、`AUTH_MODE=public` に切り替える。
-
-### R2 カスタムドメインの必須セットアップ
-
-`snapshot_url` は常に「R2 カスタムドメイン + `SNAPSHOT_OBJECT_KEY`」（既定キーなら `https://snapshot.example.com/snapshot/latest.json`）。ブラウザは両認証モードとも同 URL を直接 fetch する。
-
-運用側の設定：
-
-1. バケットを Cloudflare カスタムドメイン経由で公開する。
-2. スナップショットオブジェクトパスに `Cache Everything` の Cache Rule を追加。
-3. Edge TTL を `5 seconds` に固定。
-4. オリジン側の `Cache-Control: public, max-age=5` と整合させる。
-5. Pages と R2 カスタムドメインがクロスオリジンなら、両モードとも Pages オリジンを R2 CORS で許可する。`AUTH_MODE=access` ではさらに `Access-Control-Allow-Credentials: true` を許可。
-
-### `AUTH_MODE=access` の絶対要件
-
-`AUTH_MODE=access` が有効なのは、SPA が `snapshot_url` のポーリングを開始する前に、Pages オリジン・R2 カスタムドメイン双方で利用可能な Access セッションをブラウザが既に持っているときに限る。
-
-- 推奨: Pages / Worker `/api/history` / R2 カスタムドメインを 1 つの Access アプリ（または同等の複数ドメインポリシー）配下に置き、1 回ログインで双方の Cookie を事前に seed する。
-- 許容される代替策: R2 カスタムドメイン向け Cookie を明示的に事前 seed する（専用 R2 訪問 / サイレント事前 seed フロー）。
-- 不可: CORS のみに依存する / R2 Access Cookie が無い場合に同一オリジン Worker・Pages のスナップショットプロキシへフォールバックする。
-
-### public/access スモークチェックリスト
-
-デプロイ後・認証モード変更後に必ず実施：
-
-1. デプロイ済み UI を開き、選択モード以外が混在していないこと。
-2. `VITE_SNAPSHOT_URL` を直接ブラウザで叩く：
-   - `AUTH_MODE=public`: Access ログイン無しで 200。
-   - `AUTH_MODE=access`: Pages / R2 双方で Access セッションが確立されてからのみ 200。Pages ログイン済なのに R2 で Access challenge が残る場合はデプロイ未完了。
-3. 返答が `/api/snapshot` ではなく R2 カスタムドメインオブジェクトパスから来ていること。
-4. 同じリクエストを再実行し、`Cache Everything` + `Edge TTL = 5 seconds` により edge キャッシュ HIT（`CF-Cache-Status: HIT` 等）となること。
-5. `/api/history?agent_id=<known-agent>&limit=1` をデプロイ済 Worker に叩く：
-   - `AUTH_MODE=public`: Access ログイン無しで成功。
-   - `AUTH_MODE=access`: ログイン前は Access challenge / 失敗、ログイン後に成功。
-6. Pages と Worker `/api/history` がクロスオリジンなら、preflight / GET 応答に `Access-Control-Allow-Origin: <Pages オリジン>` が含まれ、`AUTH_MODE=access` では `Access-Control-Allow-Credentials: true` および credentialed fetch 成功も確認。
-7. Pages と R2 がクロスオリジンなら、`AUTH_MODE=access` で `Access-Control-Allow-Credentials: true` と credentialed fetch 成功も確認。
-8. 上記が `AUTH_MODE=access` で満たせない場合は Access Cookie 共有 / 事前 seed を直すか `AUTH_MODE=public` を選択。プロキシフォールバックは禁止。
-
-### 運用側に残る手動チェック項目
-
-以下は staging / preview インフラが必要で、ローカル Vitest だけでは証明できない：
-
-1. **R2 カスタムドメインの edge キャッシュ（両認証モード共通）**
-    - スナップショットオブジェクトパスに `Cache Everything` + `Edge TTL = 5 seconds` を適用。
-    - 同じオブジェクトを 2 回 fetch し、2 回目が edge HIT (`CF-Cache-Status: HIT` 等) になること（cached age は 5 秒 TTL 内）。
-    - TTL 経過後は `generated_at` / `published_at` が更新された新しいボディを返し、鮮度予算を破らないこと。
-
-2. **`AUTH_MODE=access` の Cookie 共有 / 事前 seed**
-    - Pages へのログインが R2 カスタムドメインの Access セッションも確立するか、事前 seed フローが確実に動くこと。
-    - SPA ポーリング前に、ブラウザから `snapshot_url` へ直接 `credentials: 'include'` で fetch して成功すること。
-    - R2 ドメイン側でリダイレクト / challenge が残る場合はデプロイ無効扱い。プロキシ追加禁止。
-
-3. **定周期パブリッシュ継続シナリオ**
-    - デプロイ済 Worker + UI を開いた状態で、静穏期に 3 周期以上連続で publish が走り、sub-minute 可能なトリガ（Durable Object alarm / 外部 cron / 常駐スケジューラ等）によって `generated_at` が更新され続けることを観測。
-    - R2 オブジェクトが 5 秒刻みで更新され続けるあいだ、UI が前フレームを保持し 60 秒閾値まで stale 化しないこと。
-    - 日次 Worker `scheduled()` cron は retention 専用で、この publisher トリガではないこと（単独では 5 秒鮮度を満たさない）。
-
-## Cloudflare Worker デプロイ
-
-`wrangler.toml` は git-ignore 済み。トラック済テンプレ `wrangler.toml.example` からローカル生成する：
+### 1. Cloudflare リソースを作成
 
 ```bash
-cd karakuri-world-ui
+# D1 データベース（履歴保存用）
+npx wrangler d1 create karakuri-world-ui-history
+
+# R2 バケット（スナップショット保存用）
+npx wrangler r2 bucket create karakuri-world-ui-snapshot
+npx wrangler r2 bucket create karakuri-world-ui-snapshot-preview
+```
+
+### 2. wrangler.toml を用意
+
+```bash
 cp wrangler.toml.example wrangler.toml
 ```
 
-`wrangler.toml.example` にはデプロイ不能なプレースホルダが入っている：
+`wrangler.toml` 内のプレースホルダを実際の値に書き換える：
 
-- `database_id = "00000000-0000-0000-0000-000000000000"`
-- `preview_database_id = "00000000-0000-0000-0000-000000000000"`
+- `database_id` / `preview_database_id` → D1 作成時に返された ID
+- `bucket_name` / `preview_bucket_name` → 作成した R2 バケット名
 
-R2 バケットも同様：
-
-- `bucket_name = "replace-with-real-snapshot-bucket"`
-- `preview_bucket_name = "replace-with-real-snapshot-bucket-preview"`
-
-本番デプロイ前に、UI history 用 D1 を作成または特定し、Wrangler が返した ID でローカル `wrangler.toml` の 2 箇所を置き換える。
-
-テンプレには Worker `scheduled()` ハンドラを 1 日 1 回 `03:00 UTC` に回す cron も入っている（D1 history retention 用）。本番でもこの cron（または同等の日次スケジュール）は維持する。
-
-この日次 cron は **retention 専用**で、スナップショット publisher ではない。本番 readiness にはさらに、静穏期でも publish を継続できる **sub-minute 可能な 5 秒トリガ**（Durable Object alarm / 外部 cron / 常駐スケジューラ等）が必須。
-
-例：
+### 3. シークレットを設定（初回のみ）
 
 ```bash
-cd karakuri-world-ui
-npx wrangler d1 create karakuri-world-ui-history
-npx wrangler r2 bucket create <real-snapshot-bucket>
-npx wrangler r2 bucket create <real-snapshot-bucket-preview>
+npx wrangler secret put KW_ADMIN_KEY         # Karakuri World の管理キー
+npx wrangler secret put KW_BASE_URL          # Karakuri World サーバーの URL
 ```
 
-その後 `wrangler.toml` に返された `database_id` / `preview_database_id` と実 R2 バケット名を反映し、必要なシークレット（初回のみ）を設定してからデプロイ：
+Pages と Worker がクロスオリジンの場合は CORS 許可も設定：
 
 ```bash
-npx wrangler secret put KW_ADMIN_KEY
+npx wrangler secret put HISTORY_CORS_ALLOWED_ORIGINS
+# 例: https://your-pages.pages.dev,https://ui.example.com
+```
+
+### 4. R2 バケットの CORS を設定
+
+Pages ドメインと R2 カスタムドメインがクロスオリジンの場合（通常はそう）、R2 バケットに CORS ルールを追加する：
+
+```bash
+cat > /tmp/cors.json << 'EOF'
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": ["https://your-pages-domain.example.com"],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "maxAgeSeconds": 86400
+    }
+  ]
+}
+EOF
+npx wrangler r2 bucket cors set karakuri-world-ui-snapshot --file /tmp/cors.json
+```
+
+`origins` は実際の Pages ドメイン（例: `https://karakuri-world.0235.app`）に書き換えること。設定確認は `npx wrangler r2 bucket cors list karakuri-world-ui-snapshot`。
+
+### 6. Worker をデプロイ
+
+```bash
 npm run deploy:prod
 ```
 
-`deploy:prod` は以下を順に実行するラッパ：
+このコマンドは順に：
+1. `wrangler.toml` のプレースホルダ残存チェック（あれば停止）
+2. D1 マイグレーション適用
+3. `wrangler deploy`
+4. Worker へのウォームアップリクエスト（スナップショット配信の起動）
 
-1. `wrangler.toml` にプレースホルダ値（`00000000-...` / `replace-with-real-...`）が残っていたら fail-closed で停止。
-2. `npx wrangler d1 migrations apply HISTORY_DB --remote` で D1 マイグレーションを適用。
-3. `npx wrangler deploy` でデプロイ。
-4. Worker URL に対して 1 回 `curl` を打ち、DO の `boot()` → `refreshSnapshot('boot')` → `rescheduleAlarm()` をトリガ。ウォームアップが `HTTP 200/204` 以外を返した場合はスクリプトを **失敗扱いで exit** し、snapshot publisher が休眠したままになることを防ぐ。
+> **注意**: ウォームアップが成功しないと R2 へのスナップショット発行が始まらない。
 
-この 4 つ目のウォームアップを踏まないと、次に誰かが Worker を叩くまで R2 への publish が始まらない。ウォームアップ後は DO alarm 自身が 5 秒間隔の publisher トリガとして自走するため、外部 cron を追加配線する必要はない。
+### 7. フロントエンドをデプロイ（Cloudflare Pages）
 
-最低限、`KW_BASE_URL` と Worker で使う非既定のスナップショット publisher 設定も必要。Pages と Worker `/api/history` がクロスオリジンなら `HISTORY_CORS_ALLOWED_ORIGINS` に Pages オリジンリストも設定する。`HISTORY_RETENTION_DAYS` は任意で既定 `180`、上書きする場合は Worker と cron で同じ retention ポリシーにする。
-
-リポジトリ管理の D1 スキーマは `schema/history.sql`、デプロイ用 Wrangler マイグレーションは `migrations/0001_plan05_history_schema.sql`。
-
-## Relay アラート配線と readiness ゲート
-
-Unit 32 で relay `/ws` は完全に廃止された。readiness は polling + R2/CDN の鮮度、定周期スナップショット発行、認証モードの整合性のみで構成される。relay アラート成果物（`relay-alerting-spec.json` 等）は `ui.*` と `relay.r2.*` シグナルだけをカバーし、relay WebSocket シグナルは残っていない。
-
-リポジトリ管理の正本成果物：
-
-- `worker/ops/relay-alerting-spec.json`: アラートルール / 配信ルート / clear 条件 / 認証系とネットワーク系のルート分割。
-- `worker/ops/relay-synthetic-drills.json`: staging ドリルカタログ＋期待アラート経路に到達する合成メトリックタイムライン。
-- `worker/ops/relay-production-readiness.template.json`: 本番 sign-off テンプレ（実ルート / 受信ログ / ドリル証跡 / sign-off 時刻が埋まるまで fail-closed）。
-- `worker/ops/relay-production-readiness.example.json`: レビュー / テスト用の passing 例。
-
-検証コマンド：
+`.env.local` の `VITE_*` 変数をセットしてからビルド・デプロイ：
 
 ```bash
-cd karakuri-world-ui
-npm run relay:readiness
-npm run relay:readiness -- --target=production --manifest worker/ops/relay-production-readiness.example.json --wrangler worker/test/fixtures/wrangler.production.example.toml
+npm run build
+npx wrangler pages deploy dist --project-name karakuri-world-ui-frontend \
+  --commit-dirty=true --commit-message="deploy"
 ```
 
-`npm run relay:readiness` 単体はリポ内カタログ / ドリル成果物を検証。primary の polling / R2 readiness は上記手動チェック＋ Unit 29+ の手順が別途必要。本番 relay 検証は manifest が埋まるまで fail-closed のまま。
+## 認証モード
 
-relay ゲートが満たすべき条件：
+### `AUTH_MODE=public`（推奨・シンプル）
 
-- readiness アラートは Unit 10/29+ の primary メトリクスセットを使う: `ui.snapshot.refresh_failure_total{reason}`、`ui.snapshot.generated_age_ms`、`ui.snapshot.published_age_ms`、`ui.r2.publish_failure_total`、`ui.r2.publish_failure_streak`、`ui.d1.retention_run_total{result=success}`、`ui.d1.retention_deleted_rows`。
-- sustained outage の pager ルートが実本番配信先に解決できること。
-- retention cron サイレンス（`ui.d1.retention_run_total{result=success}` が 2 日不在）、retention バックログ肥大（`ui.d1.retention_deleted_rows` がレビュー閾値超過）、R2 retry brake 飽和（`ui.r2.publish_failure_streak >= 5`、60 秒 cap に合致）が明示ゲート項目。
-- 即時（auth/config）pager ルートと sustained outage pager ルートは別の本番配信先に解決されること。
-- 本番 manifest は実通知先 / provider ルール参照 / 要求される全アラート経路の staging ドリル証跡（observed alert ID & observed route ID）/ 事前 sign-off を含むこと。
-- `wrangler.toml` に `HISTORY_DB` / `SNAPSHOT_BUCKET` バインドが無い、プレースホルダ D1/R2 のまま、日次 `03:00 UTC` retention cron が無い場合も本番検証は失敗扱い。
+Pages・Worker `/api/history`・R2 カスタムドメインがすべて公開アクセス可能。
+
+### `AUTH_MODE=access`
+
+Cloudflare Access でブラウザセッションを保護する場合。Pages・Worker・R2 の全エンドポイントを同一の Access ポリシー配下に置き、1 回ログインで全 Cookie を取得できる構成にする必要がある。
+
+## デプロイ後の確認
+
+1. `VITE_SNAPSHOT_URL` をブラウザで直接開き、JSON が返ること
+2. `/api/history?agent_id=<id>&limit=1` を Worker に叩き、応答があること
+3. UI を開いてスナップショットが定期更新されていること（60 秒以内）
+
+## R2 キャッシュ設定
+
+Cloudflare ダッシュボードでスナップショットパスに Cache Rule を追加する：
+
+- **ルール**: `Cache Everything`
+- **Edge TTL**: `5 seconds`
+
+R2 側のオブジェクトには `Cache-Control: public, max-age=5` を設定する。
+
+## テスト
+
+```bash
+npm test                       # フルスイート
+npm run test:phase1-acceptance # UI 受入ゲートのみ
+npm run relay:readiness        # アラート設定の検証
+```
+
+## 運用ファイル
+
+| ファイル | 用途 |
+|---------|------|
+| `worker/ops/relay-alerting-spec.json` | アラートルール定義 |
+| `worker/ops/relay-production-readiness.template.json` | 本番 sign-off テンプレ |
+| `schema/history.sql` | D1 スキーマ |
+| `migrations/0001_plan05_history_schema.sql` | Wrangler マイグレーション |

--- a/karakuri-world-ui/README.md
+++ b/karakuri-world-ui/README.md
@@ -2,204 +2,161 @@
 
 > 日本語版は [README.ja.md](./README.ja.md) を参照。
 
-## Spectator UI dev/build environment
+Spectator UI. Two-layer architecture: Vite/React SPA (Cloudflare Pages) + Cloudflare Worker (history API + snapshot publishing).
 
-The Vite app is fail-fast by design: both `npm run dev` and `npm run build` stop immediately unless all required browser-side variables are present.
+## Local development
 
-Create `karakuri-world-ui/.env.local` (or another Vite env file) with:
+Create `.env.local`, then start the dev server:
 
 ```bash
-VITE_SNAPSHOT_URL=https://snapshots.example.com/snapshot/latest.json
+VITE_SNAPSHOT_URL=https://snapshot.example.com/snapshot/latest.json
 VITE_AUTH_MODE=public
-VITE_API_BASE_URL=https://history.example.com/api/history
-VITE_PHASE3_EFFECTS_ENABLED=false
-VITE_PHASE3_EFFECT_RAIN_ENABLED=false
-VITE_PHASE3_EFFECT_SNOW_ENABLED=false
-VITE_PHASE3_EFFECT_FOG_ENABLED=false
-VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED=false
-VITE_PHASE3_EFFECT_MOTION_ENABLED=false
-VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED=false
+VITE_API_BASE_URL=https://your-worker.workers.dev/api/history
 ```
-
-Required values:
-
-- `VITE_SNAPSHOT_URL`: absolute browser-fetchable snapshot object URL. In plan12 this is the direct snapshot URL, typically the R2 custom domain plus the published object key. Because this value ships in the browser bundle, it must stay public-facing: use only `http` / `https`, and do not embed credentials, query params, or fragments. Do not point this at `/api/snapshot`; the browser always polls the R2 custom-domain object URL directly.
-- `VITE_AUTH_MODE`: `public` or `access`.
-- `VITE_API_BASE_URL`: absolute Worker history API endpoint. This must be the full `/api/history` URL, not just the Worker origin and not a parent path such as `/api`. Because this value is also browser-exposed, do not embed credentials, query params, or fragments.
-- `VITE_PHASE3_EFFECTS_ENABLED` (optional): `true` or `false`. Defaults to `false`; keep it off until Phase 3 effects are intentionally being exercised.
-- `VITE_PHASE3_EFFECT_RAIN_ENABLED`, `VITE_PHASE3_EFFECT_SNOW_ENABLED`, `VITE_PHASE3_EFFECT_FOG_ENABLED`, `VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED` (optional): per-effect rollout flags. Each defaults to `false`, and each only takes effect when `VITE_PHASE3_EFFECTS_ENABLED=true`, so rain / snow / fog / day-night can be rolled back independently without removing the Phase 3 foundation.
-- `VITE_PHASE3_EFFECT_MOTION_ENABLED`, `VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED` (optional): rollout flags for movement interpolation and lightweight `current_activity.emoji` particles. Both default to `false`, and both only take effect when `VITE_PHASE3_EFFECTS_ENABLED=true`, so Phase 1 static node rendering remains the fallback during staged rollout or rollback.
-
-For local verification:
 
 ```bash
 cd karakuri-world-ui
+npm install
 npm run dev
-npm run build
-npm run test:phase1-acceptance
 ```
 
-## Phase 1 acceptance gate
+`npm run dev` / `npm run build` stop immediately if any required variable is missing (fail-fast).
 
-`npm run test:phase1-acceptance` is the focused acceptance gate for the spectator UI Phase 1 behavior. The updated delivery-track pivot after Unit 28 is documented in Units 29+; this command remains the practical UI go/no-go check.
+### Environment variables
 
-The automated gate covers:
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VITE_SNAPSHOT_URL` | ✓ | Snapshot URL on the R2 custom domain (do not point at `/api/snapshot`) |
+| `VITE_AUTH_MODE` | ✓ | `public` or `access` |
+| `VITE_API_BASE_URL` | ✓ | Full URL to the Worker's `/api/history` endpoint |
+| `VITE_PHASE3_EFFECTS_ENABLED` | - | Master switch for visual effects (default `false`) |
+| `VITE_PHASE3_EFFECT_RAIN_ENABLED` etc. | - | Per-effect rollout flags (default `false`) |
 
-- desktop + mobile initial shell layout on one shared map host
-- 100-agent snapshot reflection within the Phase 1 15-second budget
-- selected agent detail remains coherent even when `/api/history` is empty or degraded
-- populated `/api/history?agent_id=...&limit=20` checks and conversation log expansion are additive comparisons when ingest/backfill is available
-- quiet-period freshness (`generated_at` refresh prevents stale before the 60-second threshold)
-- **Units 29/32 alignment**: fixed-cadence snapshot publishing, driven by a **sub-minute-capable publisher trigger**, plus direct R2 polling keep freshness inside the 15-second budget
+## Deployment
 
-Run the full suite with `npm test`; use `npm run test:phase1-acceptance` when you want the Phase 1 go/no-go gate only.
-
-## Phase 2 auth-mode deployment guide
-
-Choose exactly one auth mode per deployment: `AUTH_MODE=public` or `AUTH_MODE=access`. A deployment is valid only when Pages, Worker `/api/history`, and the R2 `snapshot_url` are all configured for that same mode.
-
-- `AUTH_MODE=public`: Pages, Worker `/api/history`, and the R2 custom domain are all publicly reachable.
-- `AUTH_MODE=access`: Pages, Worker `/api/history`, and the R2 custom domain are all protected by Cloudflare Access, and the browser fetches both `snapshot_url` and `/api/history` with `credentials: 'include'`.
-- If Pages and Worker `/api/history` are cross-origin, set Worker `HISTORY_CORS_ALLOWED_ORIGINS` to a comma-separated list of exact Pages origins (for example `https://ui.example.com,https://preview-ui.example.com`). The Worker echoes only configured origins; in `AUTH_MODE=access` it also returns `Access-Control-Allow-Credentials: true`, so `*` is not a valid substitute.
-
-Do not mix modes within one deployment, and do not add a Worker/Pages snapshot proxy fallback when `AUTH_MODE=access` preconditions are not met. If Access cookie sharing or pre-seeding cannot be guaranteed, switch the deployment to `AUTH_MODE=public` instead of proxying snapshot traffic through `/api`.
-
-### Required R2 custom-domain setup
-
-`snapshot_url` is always the R2 custom-domain URL plus `SNAPSHOT_OBJECT_KEY` (for the default key: `https://snapshot.example.com/snapshot/latest.json`). The browser fetches that URL directly in both auth modes.
-
-Required operator setup on the R2 custom domain:
-
-1. Publish the bucket through a Cloudflare custom domain.
-2. Add Cache Rules for the snapshot object path with `Cache Everything`.
-3. Fix the Edge TTL to `5 seconds`.
-4. Keep that rule aligned with the origin `Cache-Control: public, max-age=5`.
-5. If Pages and the R2 custom domain are cross-origin, configure R2 CORS so the Pages origin is allowed in both auth modes. For `AUTH_MODE=access`, also allow credentialed fetches (`Access-Control-Allow-Credentials: true`).
-
-### `AUTH_MODE=access` hard preconditions
-
-`AUTH_MODE=access` is valid only when the browser already has a usable Access session for both the Pages origin and the R2 custom domain before the SPA starts polling `snapshot_url`.
-
-- Preferred: place Pages, Worker `/api/history`, and the R2 custom domain behind one Access app or an equivalent multi-domain policy so one login pre-seeds both cookies.
-- Acceptable alternative: explicitly pre-seed the R2 custom-domain cookie before the SPA starts (for example via a dedicated R2 visit / silent pre-seeding flow).
-- Not acceptable: relying on CORS alone, or falling back to a same-origin Worker/Pages snapshot proxy when R2 Access cookies are missing.
-
-### Public/access smoke-test checklist
-
-Run the following after each deployment or auth-mode change:
-
-1. Open the deployed UI and confirm the chosen mode is the only mode in use for that deployment.
-2. Request `VITE_SNAPSHOT_URL` directly in the browser:
-   - `AUTH_MODE=public`: expect HTTP 200 without Access login.
-   - `AUTH_MODE=access`: expect HTTP 200 only after Pages and R2 Access sessions are both established; if R2 still challenges while Pages is already logged in, the deployment is not ready.
-3. Verify the snapshot response comes from the R2 custom domain object path, not `/api/snapshot`.
-4. Repeat the snapshot request and confirm edge caching (`CF-Cache-Status: HIT` or equivalent) with the `Cache Everything` + `Edge TTL = 5 seconds` rule in effect.
-5. Request `/api/history?agent_id=<known-agent>&limit=1` from the deployed Worker:
-   - `AUTH_MODE=public`: expect success without Access login.
-   - `AUTH_MODE=access`: expect an Access auth challenge/failure before login, then success after the Access session is established.
-6. If Pages and Worker `/api/history` are cross-origin, confirm the Worker preflight/GET responses include `Access-Control-Allow-Origin: <Pages origin>`, and for `AUTH_MODE=access` also confirm `Access-Control-Allow-Credentials: true` and a successful credentialed browser fetch.
-7. If Pages and R2 are cross-origin, confirm the R2 response includes the expected CORS behavior for the Pages origin in both auth modes, and for `AUTH_MODE=access` also confirm `Access-Control-Allow-Credentials: true` and a successful credentialed fetch.
-8. If any of the above fails in `AUTH_MODE=access`, fix Access cookie sharing / pre-seeding or choose `AUTH_MODE=public`; do not ship a proxy fallback.
-
-### Manual acceptance items that still require an operator
-
-The following checks still need staging/preview infrastructure and cannot be fully proven in local Vitest alone:
-
-1. **R2 custom-domain edge cache (`AUTH_MODE=public` or `AUTH_MODE=access`)**
-    - Apply `Cache Everything` + `Edge TTL = 5 seconds` on the snapshot object path served from the R2 custom domain.
-    - Request the same snapshot object twice and confirm the second response becomes an edge cache hit (`CF-Cache-Status: HIT` or equivalent) while the cached age stays within the 5-second TTL window.
-    - After the TTL rolls over, confirm the object serves a newer body with updated `generated_at` / `published_at` without breaking the freshness budget.
-
-2. **`AUTH_MODE=access` cookie sharing / pre-seeding**
-   - Confirm Pages login also establishes an R2 custom-domain Access session, or run the documented pre-seeding flow before the SPA begins polling.
-   - Verify the first direct browser fetch to `snapshot_url` succeeds with `credentials: 'include'`.
-   - If the first fetch still redirects/challenges on the R2 domain, treat the deployment as invalid rather than adding a snapshot proxy.
-
-3. **Fixed-cadence publish continuity scenario**
-    - With the deployed worker and UI open, observe at least three consecutive publish intervals during a quiet period and confirm `generated_at` continues to advance from fixed-cadence `/api/snapshot` polling driven by a **sub-minute-capable trigger** (for example a Durable Object alarm, external cron, or always-on scheduler).
-    - Confirm the UI keeps the previous render and does not enter stale before the 60-second threshold while the R2 object keeps refreshing on the 5-second cadence.
-    - The daily Worker `scheduled()` cron that exists for retention is **not** this publisher trigger and does not satisfy the 5-second freshness requirement by itself.
-
-## Cloudflare Worker deployment
-
-`wrangler.toml` is git-ignored and must be generated locally from the tracked template `wrangler.toml.example`:
+### 1. Create Cloudflare resources
 
 ```bash
-cd karakuri-world-ui
+# D1 database (history storage)
+npx wrangler d1 create karakuri-world-ui-history
+
+# R2 buckets (snapshot storage)
+npx wrangler r2 bucket create karakuri-world-ui-snapshot
+npx wrangler r2 bucket create karakuri-world-ui-snapshot-preview
+```
+
+### 2. Prepare wrangler.toml
+
+```bash
 cp wrangler.toml.example wrangler.toml
 ```
 
-`wrangler.toml.example` carries non-deployable placeholder D1 IDs:
+Replace the placeholders in `wrangler.toml` with real values:
 
-- `database_id = "00000000-0000-0000-0000-000000000000"`
-- `preview_database_id = "00000000-0000-0000-0000-000000000000"`
+- `database_id` / `preview_database_id` → IDs returned when the D1 database was created
+- `bucket_name` / `preview_bucket_name` → names of the R2 buckets you created
 
-and placeholder R2 bucket names for snapshot publishing:
-
-- `bucket_name = "replace-with-real-snapshot-bucket"`
-- `preview_bucket_name = "replace-with-real-snapshot-bucket-preview"`
-
-Before any real deploy, create or identify the UI history D1 database and replace both values in your local `wrangler.toml` with the IDs Wrangler returns.
-
-The template also schedules the worker `scheduled()` handler once per day at `03:00 UTC` so D1 history retention keeps running. Keep that cron (or an equivalent daily schedule) enabled in production.
-
-That daily `scheduled()` cron is **retention-only**. It is not the snapshot publisher. Production readiness additionally requires a separate **sub-minute-capable 5-second trigger** (for example a Durable Object alarm, external cron, or always-on scheduler) that keeps snapshot publishing running even during quiet periods.
-
-Example:
+### 3. Set secrets (first time only)
 
 ```bash
-cd karakuri-world-ui
-npx wrangler d1 create karakuri-world-ui-history
-npx wrangler r2 bucket create <real-snapshot-bucket>
-npx wrangler r2 bucket create <real-snapshot-bucket-preview>
+npx wrangler secret put KW_ADMIN_KEY         # Karakuri World admin key
+npx wrangler secret put KW_BASE_URL          # Karakuri World server URL
 ```
 
-Then update `wrangler.toml` with the emitted `database_id` / `preview_database_id` and the real R2 bucket names, set required secrets (once), and deploy:
+If Pages and Worker are cross-origin, also configure CORS:
 
 ```bash
-npx wrangler secret put KW_ADMIN_KEY
+npx wrangler secret put HISTORY_CORS_ALLOWED_ORIGINS
+# e.g. https://your-pages.pages.dev,https://ui.example.com
+```
+
+### 4. Configure R2 bucket CORS
+
+When the Pages domain and the R2 custom domain are cross-origin (which is normally the case), add a CORS rule to the R2 bucket:
+
+```bash
+cat > /tmp/cors.json << 'EOF'
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": ["https://your-pages-domain.example.com"],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "maxAgeSeconds": 86400
+    }
+  ]
+}
+EOF
+npx wrangler r2 bucket cors set karakuri-world-ui-snapshot --file /tmp/cors.json
+```
+
+Replace `origins` with your actual Pages domain (e.g. `https://karakuri-world.0235.app`). Verify with `npx wrangler r2 bucket cors list karakuri-world-ui-snapshot`.
+
+### 5. Deploy the Worker
+
+```bash
 npm run deploy:prod
 ```
 
-`deploy:prod` は以下を順に実行するラッパ：
+This command runs in order:
 
-1. `wrangler.toml` にプレースホルダ値（`00000000-...` / `replace-with-real-...`）が残っていたら fail-closed で停止
-2. `npx wrangler d1 migrations apply HISTORY_DB --remote` で D1 マイグレーションを適用
-3. `npx wrangler deploy` でデプロイ
-4. Worker URL に対して 1 回 `curl` を打ち、DO の `boot()` → `refreshSnapshot('boot')` → `rescheduleAlarm()` をトリガ
+1. Checks `wrangler.toml` for remaining placeholders (stops if found)
+2. Applies D1 migrations
+3. Runs `wrangler deploy`
+4. Sends a warm-up request to the Worker (starts snapshot publishing)
 
-この 4 つ目のウォームアップを踏まないと、次に誰かが Worker を叩くまで R2 への publish が始まらない。ウォームアップ後は DO alarm 自身が 5 秒間隔の publisher trigger として自走するため、外部 cron を追加で配線する必要はない。
+> **Note**: Snapshot publishing to R2 will not begin unless the warm-up request succeeds.
 
-At minimum, deployment also requires `KW_BASE_URL` and any non-default snapshot-publisher settings used by the worker. When Pages and Worker `/api/history` are cross-origin, also set `HISTORY_CORS_ALLOWED_ORIGINS` to the exact Pages origin list. `HISTORY_RETENTION_DAYS` remains optional and defaults to `180`, but if you override it the deployed worker and cron schedule should use the same retention policy.
+### 6. Deploy the frontend (Cloudflare Pages)
 
-The checked-in D1 schema lives at `schema/history.sql`, and the deployable Wrangler migration lives at `migrations/0001_plan05_history_schema.sql`.
-
-## Relay alert wiring and readiness gate
-
-Unit 32 removed the relay `/ws` path entirely. The readiness story is now exclusively polling + R2/CDN freshness, scheduled snapshot publishing, and auth-mode correctness. The relay alert artifacts (`relay-alerting-spec.json` etc.) cover `ui.*` and `relay.r2.*` signals only — no relay WebSocket signals remain.
-
-Authoritative repo-owned artifacts:
-
-- `worker/ops/relay-alerting-spec.json`: alert rules, routes, clear conditions, and the required auth-vs-network routing split.
-- `worker/ops/relay-synthetic-drills.json`: staging drill catalog plus synthetic metric timelines that must evaluate into the expected alert paths.
-- `worker/ops/relay-production-readiness.template.json`: production sign-off template that intentionally fails the gate until real routes, receipts, drill evidence, and sign-off timestamps are filled in.
-- `worker/ops/relay-production-readiness.example.json`: passing example manifest shape for review/tests.
-
-Validation commands:
+Set the `VITE_*` variables in `.env.local`, then build and deploy:
 
 ```bash
-cd karakuri-world-ui
-npm run relay:readiness
-npm run relay:readiness -- --target=production --manifest worker/ops/relay-production-readiness.example.json --wrangler worker/test/fixtures/wrangler.production.example.toml
+npm run build
+npx wrangler pages deploy dist --project-name karakuri-world-ui-frontend \
+  --commit-dirty=true --commit-message="deploy"
 ```
 
-`npm run relay:readiness` by itself validates the checked-in catalog/drill artifacts. Primary polling/R2 readiness still requires the separate operator checks documented above and in Units 29+; production relay validation remains fail-closed until the production manifest is filled in.
+## Auth modes
 
-Relay gate expectations:
+### `AUTH_MODE=public` (recommended — simple)
 
-- readiness alerts use the full primary `ui.*` metric set from Units 10/29+: `ui.snapshot.refresh_failure_total{reason}`, `ui.snapshot.generated_age_ms`, `ui.snapshot.published_age_ms`, `ui.r2.publish_failure_total`, `ui.r2.publish_failure_streak`, `ui.d1.retention_run_total{result=success}`, and `ui.d1.retention_deleted_rows`.
-- the sustained outage pager route must resolve to a real production destination.
-- retention cron silence (`ui.d1.retention_run_total{result=success}` absent for 2 days), large retention backlog cleanup (`ui.d1.retention_deleted_rows` crossing the review threshold), and R2 retry-brake saturation (`ui.r2.publish_failure_streak >= 5`, matching the 60-second cap) are explicit gate items.
-- the immediate auth/config pager route and the sustained outage pager route must resolve to different production destinations.
-- the production manifest must include real notification destinations, provider rule references, staging drill receipts with both observed alert IDs and observed route IDs for every required alert path, and pre-production sign-off.
-- production validation also fails if `wrangler.toml` omits the required `HISTORY_DB` / `SNAPSHOT_BUCKET` bindings, still has placeholder D1/R2 bindings, or if the daily `03:00 UTC` retention cron is missing.
+Pages, Worker `/api/history`, and the R2 custom domain are all publicly accessible.
+
+### `AUTH_MODE=access`
+
+Protects browser sessions with Cloudflare Access. Pages, Worker, and R2 must all sit behind the same Access policy so a single login establishes cookies for all three.
+
+## Post-deploy verification
+
+1. Open `VITE_SNAPSHOT_URL` directly in a browser and confirm JSON is returned.
+2. Call `/api/history?agent_id=<id>&limit=1` on the Worker and confirm a response.
+3. Open the UI and confirm the snapshot refreshes periodically (within 60 seconds).
+
+## R2 cache configuration
+
+Add a Cache Rule for the snapshot object path in the Cloudflare dashboard:
+
+- **Rule**: `Cache Everything`
+- **Edge TTL**: `5 seconds`
+
+Set `Cache-Control: public, max-age=5` on the R2 object.
+
+## Testing
+
+```bash
+npm test                       # full suite
+npm run test:phase1-acceptance # Phase 1 acceptance gate only
+npm run relay:readiness        # alert configuration validation
+```
+
+## Operations files
+
+| File | Purpose |
+|------|---------|
+| `worker/ops/relay-alerting-spec.json` | Alert rule definitions |
+| `worker/ops/relay-production-readiness.template.json` | Production sign-off template |
+| `schema/history.sql` | D1 schema |
+| `migrations/0001_plan05_history_schema.sql` | Wrangler migration |


### PR DESCRIPTION
## Summary

- `README.ja.md` の再構成（commit 087d352）に合わせて `README.md`（英語版）を更新
- フェーズ別セクションや冗長なオペレーターチェックリストを削除し、ja README と同じシンプルな構成に統一
- R2 CORS 設定の wrangler CLI 形式も英語版に反映

## Test plan

- [ ] `README.md` と `README.ja.md` の構成・内容が対応していることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)