### PR TITLE
docs: apps/{server,front} README を新設/刷新しルート README を軽量化

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,392 +4,74 @@
 
 Karakuri World は、複数エージェントがログインできる小さな仮想世界サーバーです。エージェントは世界にログインし、移動し、アクションを実行し、会話し、サーバーイベントに反応できます。
 
-この README は、技術スタックの説明よりも「何をどう使うか」に重点を置いています。
+この README はモノレポの入り口です。パッケージごとのセットアップ・API リファレンス・デプロイ手順は各 `apps/*` 配下の README にまとめています。
 
 ## このプロジェクトでできること
 
-Karakuri World は、エージェントが共有する世界を管理します。
-
 - 世界は `3-1` や `3-2` のようなノードで表現されるグリッドマップです
-- エージェントは一度登録すると、好きなタイミングでログイン / ログアウトできます
+- エージェントは管理 API または Discord スラッシュコマンドで一度登録され、以降は任意のタイミングでログイン / ログアウトできます
 - ログイン中のエージェントは移動、NPC や建物とのインタラクション、会話、サーバーイベントへの応答ができます
-- 世界時刻、天気、所持金、インベントリ、グローバルアクションのようなゲーム要素も扱えます
-- 操作と通知の窓口は複数あります
-  - REST API
-  - MCP
-  - Discord 通知と `#world-admin` の管理スラッシュコマンド
-  - ブラウザ UI 向けの publish 済み snapshot / history オブジェクト（R2/CDN から直接取得）
+- 世界時刻・天気・所持金・インベントリ・グローバルアクションといったゲーム要素も同じインターフェース上で扱えます
+- 操作と通知の窓口は同時に複数利用できます
+  - **REST API**（直接操作）
+  - **MCP**（ツール呼び出し型）
+  - **Discord**（世界からの通知と `#world-admin` の管理スラッシュコマンド）
+  - **ブラウザ UI 向けデータ**（publish 済み snapshot / history を R2/CDN から直接取得）
 
 ## 最初に知っておくとよい概念
 
-### 1. ワールドマップ
+### ワールドマップ
 
-世界は上下左右の 4 方向でつながるグリッドです。
+上下左右 4 方向でつながるグリッド。ノード種別は `normal`（通行可）、`wall`（不可）、`door`（通行可能な入口）、`building_interior`（建物内部）、`npc`（NPC 在駐で通行不可）。
 
-主なノード種別:
+### エージェントのライフサイクル
 
-- `normal`: 通行可能
-- `wall`: 通行不可
-- `door`: 通行可能な入口
-- `building_interior`: 建物内部
-- `npc`: NPC がいるため通行不可
+**登録**（管理 API、1 回）と **ログイン / ログアウト**（エージェント API、任意回）を分離。資格情報は一度発行すれば、以降は何度でもログイン / ログアウトできます。
 
-サンプル設定 `apps/server/config/example.yaml` には以下が入っています。
+### エージェント状態
 
-- スポーン地点
-- ワークショップ建物
-- Gatekeeper NPC
+常に `idle` / `moving` / `in_action` / `in_conversation` のいずれか。通常 `move` / `action` / `wait` は `idle` 専用ですが、アクティブなサーバーイベント通知の割り込みウィンドウ中だけは `in_action` / `in_conversation` からも実行できます。
 
-### 2. エージェントのライフサイクル
+### イベント駆動の世界
 
-エージェントの運用は 2 段階に分かれます。
+タイマーベースのイベント駆動で、グローバル tick ループは持ちません。移動・アクションは設定された時間後に完了し、会話はターンで進み、ランタイムのサーバーイベントは説明文付きで発火されて次の行動候補を一時的に広げます。
 
-1. 管理 API でエージェントを登録する
-2. そのエージェントが世界にログイン / ログアウトする
+### 通知と操作は別
 
-つまり、資格情報の発行と実際のログインは別です。一度登録しておけば、後は何度でも世界にログイン / ログアウトできます。
+Discord は主に世界からエージェントへの**通知**と管理スラッシュコマンドに使います。エージェント自身の操作は Discord への返信ではなく REST または MCP で行います。
 
-### 3. エージェント状態
+## リポジトリ構成
 
-エージェントは常に次のいずれかの状態です。
+npm workspaces の monorepo です：
 
-- `idle`
-- `moving`
-- `in_action`
-- `in_conversation`
+```
+./
+├── apps/
+│   ├── server/      # @karakuri-world/server   ワールドサーバー本体（REST / MCP / Discord Bot）
+│   └── front/       # @karakuri-world/front    観戦 SPA + Cloudflare Worker relay
+├── docs/
+├── skills/
+└── package.json     # workspaces 定義 + パッケージ横断スクリプト
+```
 
-この状態によって次に受け付けられる操作が決まります。通常は `move` / `action` / `wait` を始められるのは `idle` のときだけですが、アクティブなサーバーイベント通知の割り込みウィンドウ中だけは `in_action` / `in_conversation` からでもこれらを開始できます。
+パッケージごとのドキュメント：
 
-### 4. イベント駆動の世界
-
-Karakuri World はタイマーベースのイベント駆動で進みます。グローバルな tick ループはありません。
-
-たとえば次のような動きです。
-
-- 移動は設定時間後に完了する
-- アクションはそれぞれの所要時間後に完了する
-- 会話はターンとインターバルで進む
-- サーバーイベントはランタイムに説明文付きで発火され、対象エージェントの次の行動候補を一時的に広げることがある
-
-### 5. 通知と操作は別
-
-Discord は主に世界からの通知用で、管理者向けには `#world-admin` のスラッシュコマンドも使います。
-
-エージェントは Discord に返信して世界を操作するのではなく、REST または MCP を使って操作します。管理者は Discord スラッシュコマンドからエージェント管理も行えます。
+- [`apps/server/README.ja.md`](./apps/server/README.ja.md) — ワールドサーバーのセットアップ、REST / MCP / 管理 / Discord、設定ファイル
+- [`apps/front/README.ja.md`](./apps/front/README.ja.md) — 観戦 SPA + Worker relay のセットアップ、デプロイ、認証モード
 
 ## クイックスタート
 
-このリポジトリは npm workspaces の monorepo です。`apps/server/` がワールドサーバー（`@karakuri-world/server`）、`apps/front/` が観戦 SPA + Cloudflare Worker relay（`@karakuri-world/front`）です。
-
-### 1. 依存関係を入れる
-
-リポジトリルートで一度だけ叩けば、両 workspace の依存がまとめて入ります。
+依存関係はルートで一度だけ叩けば、両 workspace 分まとめて入ります：
 
 ```bash
 npm install
 ```
 
-### 2. 環境変数を用意する
-
-```bash
-cp apps/server/.env.example apps/server/.env
-```
-
-`apps/server/.env` を必要に応じて編集します。
-
-| 変数 | 必須 | 説明 |
-| --- | --- | --- |
-| `ADMIN_KEY` | 必須 | 管理 API 用。`X-Admin-Key` で送る |
-| `PORT` | 任意 | 既定値は `3000` |
-| `CONFIG_PATH` | 任意 | 既定値は `./config/example.yaml`（`apps/server/` から見た相対パス） |
-| `PUBLIC_BASE_URL` | 任意 | 既定値は `http://127.0.0.1:{PORT}` |
-| `DISCORD_TOKEN` | 必須 | World Bot 用の Bot Token |
-| `DISCORD_GUILD_ID` | 必須 | 接続先 Discord サーバー ID |
-| `OPENWEATHERMAP_API_KEY` | 任意 | `config.weather` があるときの天気取得 API キー |
-| `STATUS_BOARD_DEBOUNCE_MS` | 任意 | `#world-status` の更新デバウンス間隔。既定値は `3000` |
-| `SNAPSHOT_PUBLISH_BASE_URL` | 必須 | `/api/publish-snapshot` と `/api/publish-agent-history` を受け付ける観戦 relay Worker のベース URL |
-| `SNAPSHOT_PUBLISH_AUTH_KEY` | 必須 | バックエンドが観戦 relay Worker へ snapshot/history 更新を publish するときに使う共有 Bearer トークン |
-
-`apps/server/.env.example` をそのままコピーした場合は、`PUBLIC_BASE_URL` を実際のローカル URL へ直してください。たとえば `http://127.0.0.1:3000` です。
-
-Discord トークン / Guild ID の取得手順、招待権限、必要なサーバー構成は [`docs/discord-setup.ja.md`](./docs/discord-setup.ja.md) を参照してください。
-
-### 3. サーバーを起動する
-
-開発用:
-
-```bash
-npm run dev:server
-```
-
-ビルドして起動:
-
-```bash
-npm run build:server
-npm start
-```
-
-既定では `3000` 番ポートで起動します。観戦 SPA は別プロセスとして `npm run dev:front` で起動します。
-
-## 最初の操作手順
-
-### 手順 1. エージェントを登録する
-
-管理 API または `#world-admin` の `/agent-register` を使ってエージェントを作成し、API キーを受け取ります。このコマンドは、後述の「管理者向け操作」にある `admin` ロール限定 6 コマンドの一つです。
-
-登録時に必要なのは Discord ユーザー ID のみです。bot・人間どちらのアカウントでも登録できます。サーバーはその ID を `agent_id` として使い、Discord API からユーザー名を `agent_name` として取得し、Webhook 用にアバター URL も保存します。
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/admin/agents \
-  -H "X-Admin-Key: change-me" \
-  -H "Content-Type: application/json" \
-  -d '{"discord_bot_id":"123456789012345678"}'
-```
-
-レスポンス例:
-
-```json
-{
-  "agent_id": "123456789012345678",
-  "api_key": "karakuri_...",
-  "api_base_url": "http://127.0.0.1:3000/api",
-  "mcp_endpoint": "http://127.0.0.1:3000/mcp"
-}
-```
-
-### 手順 2. ワールドにログインする
-
-受け取った `api_key` を Bearer token として使います。Discord からなら `#world-admin` の `/login-agent` でもログインできます。
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/login \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-レスポンス例:
-
-```json
-{
-  "channel_id": "1234567890",
-  "node_id": "3-1"
-}
-```
-
-`channel_id` はそのエージェント専用の Discord チャンネルです。
-
-### 手順 3. 世界情報の再取得を依頼する
-
-知覚情報の再取得:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/perception \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-利用可能アクションの再取得:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/actions \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-マップ全体の取得依頼:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/map \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-ログイン中エージェント一覧の取得依頼:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/world-agents \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-上記 4 つの参照系エンドポイントは、いずれも次のレスポンスを返します。
-
-```json
-{
-  "ok": true,
-  "message": "正常に受け付けました。結果が通知されるまで待機してください。"
-}
-```
-
-詳細結果は Discord の専用チャンネル通知で届きます。`get_perception` と `get_available_actions` の通知には次の行動候補も含まれ、`get_map` と `get_world_agents` は情報のみの通知です。
-
-### 手順 4. ワールド内で行動する
-
-移動:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/move \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"target_node_id":"3-2"}'
-```
-
-アクション実行:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/action \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"action_id":"greet-gatekeeper"}'
-```
-
-可変時間アクションでは `duration_minutes` も指定できます。
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/action \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"action_id":"sleep-house-a","duration_minutes":120}'
-```
-
-`POST /api/agents/action` は常に同じ notification-accepted レスポンスを返します。成功・所持金不足・必要アイテム不足・完了予定時刻などは Discord 通知と world log に非同期で届きます。
-
-会話開始:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/conversation/start \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"target_agent_id":"987654321098765432","message":"Hello"}'
-```
-
-会話中の操作:
-
-- `POST /api/agents/conversation/accept`
-- `POST /api/agents/conversation/join`（`conversation_id` のみ。反映は次のターン境界）
-- `POST /api/agents/conversation/stay`
-- `POST /api/agents/conversation/leave`
-- `POST /api/agents/conversation/reject`
-- `POST /api/agents/conversation/speak`（`next_speaker_agent_id` 必須）
-- `POST /api/agents/conversation/end`（`next_speaker_agent_id` 必須。2人会話では終了、3人以上では自分だけ退出。`next_speaker_agent_id` は2人会話では参照されないが、schema の一貫性のため非空文字列を必須とする）
-
-`conversation_join` は現在話者を途中で割り込ませず、次のターン境界で参加者へ反映されます。会話通知の参加者一覧には `agent_name` と `agent_id` の両方が表示されるため、`next_speaker_agent_id` をそのまま選べます。
-
-サーバーイベント通知には、その時点で実行できる move / action / wait などの選択肢が含まれます。サーバーイベントウィンドウ中は `in_action` / `in_conversation` のエージェントでも新しい move / action / wait をすぐ開始でき、現在の行動はキャンセルされます。active な会話参加者は closing に移行してから実行し、まだターン境界で未反映の pending joiner は会話から切り離されて単独で実行します。移動完了後に遅延配信された場合も、この割り込みウィンドウは遅延 `server_event_fired` 通知の直後までは維持され、次のエージェント向け通知で閉じます。`conversation_start` は受信側エージェントが `idle` のときだけ表示されます。
-
-### 手順 5. ワールドからログアウトする
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/logout \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-## 管理者向け操作
-
-よく使う管理 API:
-
-- `POST /api/admin/agents`
-- `GET /api/admin/agents`
-- `DELETE /api/admin/agents/:agent_id`
-- `POST /api/admin/server-events/fire`
-
-Discord では、次の 6 個のスラッシュコマンドも提供します。いずれも `#world-admin` チャンネルかつ `admin` ロール所持者に限定されます。
-
-- `/agent-list`
-- `/agent-register`
-- `/agent-delete`
-- `/fire-event`
-- `/login-agent`
-- `/logout-agent`
-
-ランタイムのサーバーイベントを発火する例:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/admin/server-events/fire \
-  -H "X-Admin-Key: change-me" \
-  -H "Content-Type: application/json" \
-  -d '{"description":"急に空が暗くなり、激しい雨が降り始めた。"}'
-```
-
-## MCP の使い方
-
-MCP のエンドポイント:
-
-```text
-http://127.0.0.1:3000/mcp
-```
-
-MCP でも、エージェント REST API と同じ Bearer token を使って認証します。ライフサイクルのログイン / ログアウト操作は REST 専用です。
-
-利用できる MCP ツール:
-
-- `move`
-- `action`
-- `wait`
-- `conversation_start`
-- `conversation_accept`
-- `conversation_join`
-- `conversation_stay`
-- `conversation_leave`
-- `conversation_reject`
-- `conversation_speak`
-- `end_conversation`
-- `get_available_actions`
-- `get_perception`
-- `get_map`
-- `get_world_agents`
-
-`get_perception` / `get_available_actions` / `get_map` / `get_world_agents` も同じ受理レスポンスを返し、詳細は Discord 通知で届きます。`move` / `action` / `wait` は MCP でも REST と同じ割り込みルールに従い、通常は `idle` 専用ですが、アクティブなサーバーイベント通知の割り込みウィンドウ中だけは `in_action` / `in_conversation` からでも実行できます。
-
-HTTP を直接叩くより、ツール呼び出し型のエージェント実行基盤と相性がよい場合はこちらを使ってください。
-
-## Discord 通知
-
-Discord 連携は必須です。ログインしたエージェントごとに専用チャンネルが作られ、そのチャンネルに世界名・世界観・エージェント表示名を含む通知や行動促進が送られ、`#world-log` に世界全体のログが流れ、`#world-status` には最新のワールド要約とレンダリング済みマップ画像が表示されます。
-
-行動可能な通知には `選択肢:` ブロックが含まれ、最新の周囲情報と次の行動候補をまとめて確認できます。
-
-Discord はエージェント向け通知を担い、エージェント自身の操作は引き続き REST または MCP で行います。管理者は `#world-admin` の Discord スラッシュコマンドからワールド管理を行えます。
-
-セットアップの詳細は [`docs/discord-setup.ja.md`](./docs/discord-setup.ja.md) を参照してください。
-
-## ブラウザ UI のデータ経路
-
-ブラウザで動くダッシュボードや観戦 UI は、publish 済み R2/CDN オブジェクトを直接取得します。
-
-- `snapshot/latest.json`（5 秒周期で polling、edge は `Cache-Control: public, max-age=5` でキャッシュ）が現在状態の描画用
-- `history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json` がタイムライン / 詳細オーバーレイ用
-
-world サーバーは event-driven に `POST /api/publish-snapshot` と `POST /api/publish-agent-history` を観戦 relay Worker へ push し、Worker はそれを R2 に書き込みます。edge キャッシュが 5 秒で揃うため、観戦者数が増えても origin への GET は線形に増えません。Worker には read 系 endpoint は無く、legacy `/ws` endpoint も削除済みです。
-
-`apps/front/` の観戦 SPA は `npm run dev:front` / `npm run build:front` のどちらでも、次の Vite env が必須です。
-
-- `VITE_SNAPSHOT_URL`: ブラウザが直接取得する snapshot alias (`snapshot/latest.json`) の絶対 URL。history オブジェクト URL はこの origin から派生します。
-- `VITE_AUTH_MODE`: `public` または `access`
-
-これらの URL はブラウザ bundle に露出するため、認証情報・query parameter・fragment を埋め込まないでください。詳細な契約は [`docs/design/detailed/15-ui-application-shell.md`](./docs/design/detailed/15-ui-application-shell.md) と [`apps/front/README.ja.md`](./apps/front/README.ja.md) を参照してください。
-
-## 設定ファイル
-
-サンプルワールドは次にあります。
-
-```text
-apps/server/config/example.yaml
-```
-
-このファイルで次を調整できます。
-
-- 世界名と説明
-- 移動時間
-- 会話のターン制約やタイムアウト
-- 知覚範囲
-- スポーン地点
-- マップサイズと特殊ノード
-- 建物と建物アクション
-- NPC と NPC アクション
-
-ランタイムサーバーイベントは YAML ではなく管理 API から説明文付きで発火します。
-
-別ワールドを使いたい場合は `apps/server/config/example.yaml` をコピーして、`CONFIG_PATH` で差し替えてください。
+続いて [`apps/server/README.ja.md`](./apps/server/README.ja.md#セットアップ) の手順に従って `apps/server/.env` を用意し、ワールドサーバーを起動してください。観戦 UI は任意で、セットアップは [`apps/front/README.ja.md`](./apps/front/README.ja.md) にあります。
 
 ## よく使うコマンド
 
-ルートから workspace パススルースクリプトで叩くのが基本です。
+ルートから workspace パススルースクリプトで叩くのが基本です：
 
 ```bash
 npm run dev:server      # ワールドサーバー
@@ -400,18 +82,23 @@ npm run typecheck       # 両パッケージの型チェック
 npm test                # 両パッケージの vitest run
 ```
 
-単一テストの例:
+単一テストの例：
 
 ```bash
 npm test -w @karakuri-world/server -- test/unit/domain/movement.test.ts
+npm test -w @karakuri-world/front  -- app/test/app-shell.test.tsx
 ```
+
+Docker でサーバーを立てる場合（`npm run docker:up` / `docker:down` / `docker:logs`）は [`apps/server/README.ja.md`](./apps/server/README.ja.md#3-起動する) を参照してください。
 
 ## 次に見るとよい場所
 
-- `apps/server/config/example.yaml`
-- `docs/design/world-system.md`
-- `docs/design/communication-layer.md`
-- `apps/front/README.ja.md`（観戦 SPA / Worker relay セットアップ）
+- [`apps/server/README.ja.md`](./apps/server/README.ja.md) — REST API / MCP / 管理 / Discord / 設定
+- [`apps/front/README.ja.md`](./apps/front/README.ja.md) — 観戦 UI と Worker relay
+- [`apps/server/config/example.yaml`](./apps/server/config/example.yaml) — サンプルワールド
+- [`docs/design/world-system.md`](./docs/design/world-system.md) — ワールド設計概要
+- [`docs/design/communication-layer.md`](./docs/design/communication-layer.md) — 通信モデル
+- [`docs/discord-setup.ja.md`](./docs/discord-setup.ja.md) — Discord トークン / Guild / チャンネル準備
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -4,392 +4,74 @@
 
 Karakuri World is a multi-agent world server. It runs a small node-based world where agents can log in, move, perform actions, talk to each other, and respond to server events.
 
-This README focuses on the ideas you need to use the project and the quickest way to get it running.
+This README is the entry point for the monorepo. Package-level setup, API reference, and deployment details live inside each `apps/*` package.
 
 ## What this project does
 
-Karakuri World manages a shared world for agents.
-
 - The world is a grid of nodes such as `3-1` and `3-2`.
-- Agents are registered once, then log in to and out of the world whenever needed.
+- Agents are registered once (via the admin API or a Discord slash command) and can log in to / out of the world any number of times afterward.
 - Once inside the world, an agent can move, interact with NPCs and buildings, start conversations, and react to server events.
-- The world can also expose game-layer data such as world time, weather, money, inventory items, and global item-use actions.
-- The server exposes multiple interaction surfaces:
-  - REST API for direct control
-  - MCP tools for agent/tool-based control
-  - Discord notifications for world updates plus admin slash commands in `#world-admin`
-  - Browser-facing UI data via published snapshot and history objects served directly from R2/CDN
+- Game-layer data — world time, weather, money, inventory items, global item-use actions — is exposed through the same interfaces.
+- The server exposes multiple interaction surfaces simultaneously:
+  - **REST API** for direct control
+  - **MCP** for agent/tool-based control
+  - **Discord** for outbound notifications plus admin slash commands in `#world-admin`
+  - **Browser UI data** via published snapshot and history objects served directly from R2/CDN
 
 ## Core concepts
 
-### 1. World map
+### World map
 
-The world is a grid map with four-direction adjacency.
+Grid with four-direction adjacency. Node types: `normal` (walkable), `wall` (blocked), `door` (walkable entrance), `building_interior` (walkable interior), `npc` (occupied, not walkable).
 
-Node types matter:
+### Agent lifecycle
 
-- `normal`: walkable
-- `wall`: blocked
-- `door`: walkable entrance
-- `building_interior`: walkable interior space
-- `npc`: occupied by an NPC, not walkable
+Two separate steps: **register** (admin API, once) and **log in / out** (agent API, any number of times). Issue credentials once, run many play sessions.
 
-The sample world in `apps/server/config/example.yaml` includes:
+### Agent states
 
-- spawn points
-- a workshop building
-- a gatekeeper NPC
+An agent is always `idle`, `moving`, `in_action`, or `in_conversation`. Normally `move` / `action` / `wait` require `idle`, but an active server-event window temporarily lets `in_action` / `in_conversation` agents interrupt into those commands.
 
-### 2. Agent lifecycle
+### Event-driven world
 
-There are two separate steps:
+Timer-based, no global tick loop. Movement completes after a configured delay, actions complete after their own duration, conversations advance through timed turns, and runtime server events can widen the next-command choices.
 
-1. Register an agent through the admin API
-2. Log in to or out of the world with that agent's API key
+### Notifications vs control
 
-This makes setup and play sessions separate. You can issue credentials once, then let an agent log in to and out of the world many times.
+Discord is primarily **outbound** (world → agent), plus admin slash commands. Agents act through REST or MCP, not by replying on Discord.
 
-### 3. Agent states
+## Repository layout
 
-An agent is always in one of these states:
+npm workspaces monorepo:
 
-- `idle`
-- `moving`
-- `in_action`
-- `in_conversation`
+```
+./
+├── apps/
+│   ├── server/      # @karakuri-world/server   world server (REST / MCP / Discord bot)
+│   └── front/       # @karakuri-world/front    spectator SPA + Cloudflare Worker relay
+├── docs/
+├── skills/
+└── package.json     # workspaces definition + cross-package scripts
+```
 
-These states control what the agent can do next. Normally an agent starts `move`, `action`, and `wait` while `idle`, but an active server-event window temporarily lets `in_action` or `in_conversation` agents interrupt into those commands.
+Package-level docs:
 
-### 4. Event-driven world
-
-The world is timer-based and event-driven. It does not run on a global tick loop.
-
-That means:
-
-- movement completes after a configured delay
-- actions complete after their own duration
-- conversations advance through timed turns
-- runtime server events can be fired with a free-form description and may temporarily widen the agent's next-command choices
-
-### 5. Notifications vs control
-
-Discord is primarily for outbound notifications from the world, plus admin slash commands in `#world-admin`.
-
-Agents do not control the world by sending Discord messages back. They act through REST or MCP instead, while guild admins can manage agents from Discord slash commands.
+- [`apps/server/README.md`](./apps/server/README.md) — world server setup, REST / MCP / admin / Discord usage, configuration
+- [`apps/front/README.md`](./apps/front/README.md) — spectator SPA + Worker relay setup, deployment, auth modes
 
 ## Quick start
 
-This repository is a npm workspaces monorepo. `apps/server/` is the world server (`@karakuri-world/server`) and `apps/front/` is the spectator SPA + Cloudflare Worker relay (`@karakuri-world/front`).
-
-### 1. Install dependencies
-
-Run once at the repo root; both workspaces are installed together.
+Install once at the repo root; both workspaces install together.
 
 ```bash
 npm install
 ```
 
-### 2. Prepare environment variables
-
-```bash
-cp apps/server/.env.example apps/server/.env
-```
-
-Edit `apps/server/.env` as needed:
-
-| Variable | Required | Notes |
-| --- | --- | --- |
-| `ADMIN_KEY` | Yes | Used by admin endpoints via `X-Admin-Key` |
-| `PORT` | No | Defaults to `3000` |
-| `CONFIG_PATH` | No | Defaults to `./config/example.yaml` (resolved from `apps/server/`) |
-| `PUBLIC_BASE_URL` | No | Defaults to `http://127.0.0.1:{PORT}` |
-| `DISCORD_TOKEN` | Yes | Bot token for the world bot |
-| `DISCORD_GUILD_ID` | Yes | Target Discord server ID |
-| `OPENWEATHERMAP_API_KEY` | No | Enables periodic weather polling when `config.weather` is configured |
-| `STATUS_BOARD_DEBOUNCE_MS` | No | Debounce interval for `#world-status` refreshes. Defaults to `3000` |
-| `SNAPSHOT_PUBLISH_BASE_URL` | Yes | Base URL of the spectator relay Worker that accepts `/api/publish-snapshot` and `/api/publish-agent-history` |
-| `SNAPSHOT_PUBLISH_AUTH_KEY` | Yes | Shared bearer token used by the backend when publishing snapshot/history updates to the spectator relay Worker |
-
-If you copied `apps/server/.env.example` as-is, make sure `PUBLIC_BASE_URL` points to your actual local server, for example `http://127.0.0.1:3000`.
-
-For a full guide to Discord token retrieval, guild ID lookup, invite permissions, and required server structure, see [`docs/discord-setup.md`](./docs/discord-setup.md).
-
-### 3. Start the server
-
-For development:
-
-```bash
-npm run dev:server
-```
-
-For a build-and-run flow:
-
-```bash
-npm run build:server
-npm start
-```
-
-By default the server starts on port `3000`. The spectator UI is started separately with `npm run dev:front`.
-
-## First session: admin flow and agent flow
-
-### Step 1. Register an agent
-
-Use the admin API or `/agent-register` in `#world-admin` to create an agent and receive an API key. That command is part of the full admin-only slash-command set listed in [Admin operations](#admin-operations).
-
-Registration only needs a Discord user ID. Both bot and human accounts are accepted. The server uses that ID as `agent_id`, fetches the username as `agent_name`, and stores the avatar URL for webhook-based world-log posts.
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/admin/agents \
-  -H "X-Admin-Key: change-me" \
-  -H "Content-Type: application/json" \
-  -d '{"discord_bot_id":"123456789012345678"}'
-```
-
-Typical response:
-
-```json
-{
-  "agent_id": "123456789012345678",
-  "api_key": "karakuri_...",
-  "api_base_url": "http://127.0.0.1:3000/api",
-  "mcp_endpoint": "http://127.0.0.1:3000/mcp"
-}
-```
-
-### Step 2. Log in to the world
-
-Use the returned `api_key` as a bearer token, or trigger login from Discord with `/login-agent` in `#world-admin`.
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/login \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-Typical response:
-
-```json
-{
-  "channel_id": "1234567890",
-  "node_id": "3-1"
-}
-```
-
-`channel_id` is the dedicated Discord channel for that agent.
-
-### Step 3. Request updated world information
-
-Perception refresh request:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/perception \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-Available actions refresh:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/actions \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-Full map request:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/map \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-Logged-in agents request:
-
-```bash
-curl http://127.0.0.1:3000/api/agents/world-agents \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-Each of the four read endpoints above returns:
-
-```json
-{
-  "ok": true,
-  "message": "正常に受け付けました。結果が通知されるまで待機してください。"
-}
-```
-
-The detailed result arrives through the agent's Discord notification channel. `get_perception` and `get_available_actions` include the latest action choices; `get_map` and `get_world_agents` send info-only notifications.
-
-### Step 4. Do something in the world
-
-Move:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/move \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"target_node_id":"3-2"}'
-```
-
-Run an action:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/action \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"action_id":"greet-gatekeeper"}'
-```
-
-Variable-duration actions can include `duration_minutes`:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/action \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"action_id":"sleep-house-a","duration_minutes":120}'
-```
-
-`POST /api/agents/action` now always returns the same notification-accepted payload. Success, insufficient money, missing required items, and the scheduled completion time are delivered asynchronously through Discord notifications and the world log.
-
-Start a conversation:
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/conversation/start \
-  -H "Authorization: Bearer karakuri_..." \
-  -H "Content-Type: application/json" \
-  -d '{"target_agent_id":"987654321098765432","message":"Hello"}'
-```
-
-Accept, reject, join, or speak in a conversation:
-
-- `POST /api/agents/conversation/accept`
-- `POST /api/agents/conversation/join` (`conversation_id` only; applied on the next turn boundary)
-- `POST /api/agents/conversation/stay`
-- `POST /api/agents/conversation/leave`
-- `POST /api/agents/conversation/reject`
-- `POST /api/agents/conversation/speak` (`next_speaker_agent_id` required)
-- `POST /api/agents/conversation/end` (`next_speaker_agent_id` required; ends 2-person conversations and leaves 3+ conversations. For 2-person conversations `next_speaker_agent_id` is required by the schema for consistency but not read by the server)
-
-Join requests are deferred so they never interrupt the current speaker mid-turn. Conversation prompts include both agent names and IDs so `next_speaker_agent_id` can be chosen directly.
-
-Server event notifications now include the currently available actions. During the server event window, an `in_action` or `in_conversation` agent can immediately start a new move/action/wait command; the current action is cancelled, active conversation participants move into closing first, and deferred pending joiners are detached from the conversation instead. If the notification is delayed until movement finishes, that interruption window stays open through the delayed server-event message and closes on the following agent-facing notification. `conversation_start` is only shown when the receiving agent is idle.
-
-### Step 5. Log out of the world
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/agents/logout \
-  -H "Authorization: Bearer karakuri_..."
-```
-
-## Admin operations
-
-Useful admin endpoints:
-
-- `POST /api/admin/agents`
-- `GET /api/admin/agents`
-- `DELETE /api/admin/agents/:agent_id`
-- `POST /api/admin/server-events/fire`
-
-Discord also exposes six slash commands for admins. All of them are restricted to the `#world-admin` channel and members with the `admin` role:
-
-- `/agent-list`
-- `/agent-register`
-- `/agent-delete`
-- `/fire-event`
-- `/login-agent`
-- `/logout-agent`
-
-Example: trigger a runtime server event.
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/admin/server-events/fire \
-  -H "X-Admin-Key: change-me" \
-  -H "Content-Type: application/json" \
-  -d '{"description":"Dark clouds gather and rain starts to pour."}'
-```
-
-## Using MCP
-
-The MCP endpoint is:
-
-```text
-http://127.0.0.1:3000/mcp
-```
-
-Authenticate MCP requests with the same bearer token you use for the agent REST API. Lifecycle login/logout remains REST-only.
-
-The server exposes these MCP tools:
-
-- `move`
-- `action`
-- `wait`
-- `conversation_start`
-- `conversation_accept`
-- `conversation_join`
-- `conversation_stay`
-- `conversation_leave`
-- `conversation_reject`
-- `conversation_speak`
-- `end_conversation`
-- `get_available_actions`
-- `get_perception`
-- `get_map`
-- `get_world_agents`
-
-`get_perception`, `get_available_actions`, `get_map`, and `get_world_agents` also return the same acknowledgment payload and deliver their detailed result through Discord notifications. `move`, `action`, and `wait` follow the same server-event interruption rule over MCP as they do over REST: they normally require `idle`, but an active server-event window also allows them from `in_action` / `in_conversation`.
-
-Use MCP if your agent runtime prefers tools over manual HTTP calls.
-
-## Discord notifications
-
-Discord integration is required. The server creates a dedicated channel per logged-in agent, posts world updates and prompts there, sends world-level activity logs to `#world-log`, and maintains a read-only `#world-status` board with the latest world summary plus a rendered map image.
-
-Actionable notifications now include a `選択肢:` block so agents can continue from the latest notification without separately polling for nearby actions. Perception notifications can also include world time, weather, current money, and held items. Available-action listings now keep money/item-gated actions visible, annotated with `cost_money`, `reward_money`, and `required_items` details so agents can plan around shortages.
-
-Discord delivers outbound notifications to agents, while agent actions still go through REST or MCP. Administrators can also manage the world from the `#world-admin` channel via Discord slash commands.
-
-For the full setup guide, see [`docs/discord-setup.md`](./docs/discord-setup.md).
-
-## Browser UI data path
-
-For dashboards or spectator clients running in the browser, use the published R2/CDN objects directly:
-
-- `snapshot/latest.json` (alias polled every 5 seconds, cached at the edge with `max-age=5`) for current-state rendering
-- `history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json` for timeline / detail overlays
-
-World server pushes updates event-driven to the spectator relay Worker via `POST /api/publish-snapshot` and `POST /api/publish-agent-history`; the Worker writes the payload to R2 so the edge can serve the next fetch within the same 5-second cache window. The Worker exposes no read-side endpoints, and the legacy `/ws` endpoint has been removed.
-
-The spectator SPA under `apps/front/` has its own required Vite env for both `npm run dev:front` and `npm run build:front`:
-
-- `VITE_SNAPSHOT_URL`: absolute snapshot alias URL (`snapshot/latest.json`) fetched directly by the browser. History object URLs are derived from its origin.
-- `VITE_AUTH_MODE`: `public` or `access`
-
-These browser-exposed URLs must stay public-facing, so do not embed credentials, query params, or fragments. For the tracked contract details, see [`docs/design/detailed/15-ui-application-shell.md`](./docs/design/detailed/15-ui-application-shell.md) and the setup guide at [`apps/front/README.md`](./apps/front/README.md).
-
-## Configuration guide
-
-The sample world lives in:
-
-```text
-apps/server/config/example.yaml
-```
-
-This file controls:
-
-- world name and description
-- movement timing
-- conversation timing and limits
-- perception range
-- spawn nodes
-- map size and special nodes
-- buildings and their actions
-- NPCs and their actions
-
-Runtime server events are triggered from the admin API with a free-form description rather than stored in YAML.
-
-If you want a different world, copy `apps/server/config/example.yaml` and point `CONFIG_PATH` to your custom file.
+Then follow the setup steps in [`apps/server/README.md`](./apps/server/README.md#setup) to configure `apps/server/.env` and start the world server. The spectator UI is optional and has its own setup in [`apps/front/README.md`](./apps/front/README.md).
 
 ## Useful commands
 
-Run from the repo root; the workspaces scripts dispatch to the right package.
+Run from the repo root; the workspace scripts dispatch to the right package.
 
 ```bash
 npm run dev:server      # world server
@@ -404,14 +86,19 @@ Single-test example:
 
 ```bash
 npm test -w @karakuri-world/server -- test/unit/domain/movement.test.ts
+npm test -w @karakuri-world/front  -- app/test/app-shell.test.tsx
 ```
+
+Docker-based server deployment shortcuts (`npm run docker:up` / `docker:down` / `docker:logs`) are documented in [`apps/server/README.md`](./apps/server/README.md#3-start-the-server).
 
 ## Where to look next
 
-- `apps/server/config/example.yaml` for the sample world
-- `docs/design/world-system.md` for the world design overview
-- `docs/design/communication-layer.md` for the communication model
-- `apps/front/README.md` for the spectator UI and Worker relay setup
+- [`apps/server/README.md`](./apps/server/README.md) — REST API, MCP, admin, Discord, configuration
+- [`apps/front/README.md`](./apps/front/README.md) — spectator UI and Worker relay
+- [`apps/server/config/example.yaml`](./apps/server/config/example.yaml) — sample world
+- [`docs/design/world-system.md`](./docs/design/world-system.md) — world design overview
+- [`docs/design/communication-layer.md`](./docs/design/communication-layer.md) — communication model
+- [`docs/discord-setup.md`](./docs/discord-setup.md) — Discord token / guild / channel setup
 
 ## License
 

--- a/apps/front/README.ja.md
+++ b/apps/front/README.ja.md
@@ -1,190 +1,187 @@
 # @karakuri-world/front
 
-このパッケージは観戦 SPA（`app/`）と Cloudflare Worker relay（`worker/`）を含む。Karakuri World モノレポの `apps/front/` workspace にあたる。以下のコマンドは `apps/front/` 内で実行するか、リポジトリルートから `npm run dev:front` / `npm run build:front` / `npm test -w @karakuri-world/front` で叩く。
+観戦用 UI。Vite/React SPA（Cloudflare Pages）+ Cloudflare Worker（Durable Object による snapshot/history publish）の 2 層構成で、Karakuri World モノレポの `apps/front/` workspace にあたる。
 
-## 観戦 UI の開発・ビルド環境
+以下のコマンドは `apps/front/` 内で実行するか、リポジトリルートから `npm run dev:front` / `npm run build:front` / `npm test -w @karakuri-world/front` で叩く。
 
-この Vite アプリは fail-fast 方針で、必要なブラウザ側の環境変数が揃っていない場合は `npm run dev` / `npm run build` が即座に停止する。
+## ローカル開発
 
-`apps/front/.env.local`（または他の Vite env ファイル）を作成する：
+`.env.local` を作成してから起動する：
 
 ```bash
-VITE_SNAPSHOT_URL=https://snapshots.example.com/snapshot/latest.json
+VITE_SNAPSHOT_URL=https://snapshot.example.com/snapshot/latest.json
 VITE_AUTH_MODE=public
-VITE_PHASE3_EFFECTS_ENABLED=false
-VITE_PHASE3_EFFECT_RAIN_ENABLED=false
-VITE_PHASE3_EFFECT_SNOW_ENABLED=false
-VITE_PHASE3_EFFECT_FOG_ENABLED=false
-VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED=false
-VITE_PHASE3_EFFECT_MOTION_ENABLED=false
-VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED=false
 ```
-
-### 必須項目
-
-- `VITE_SNAPSHOT_URL`: ブラウザから直接 fetch できるスナップショット alias URL（R2/CDN の `snapshot/latest.json`）の絶対パス。ブラウザはこのオブジェクトを 5 秒周期で polling し、edge は `Cache-Control: public, max-age=5` で同期する。history オブジェクト (`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`) は同じ origin から派生して取得されるため、別 URL は不要。ブラウザバンドルに同梱される値なので、`http` / `https` のみ、かつ認証情報・クエリ・フラグメントを含めてはならない。
-- `VITE_AUTH_MODE`: `public` または `access` のいずれか。
-- `VITE_PHASE3_EFFECTS_ENABLED`（任意）: `true` / `false`。既定値 `false`。意図的に Phase 3 エフェクトを検証するとき以外は OFF のままにする。
-- `VITE_PHASE3_EFFECT_RAIN_ENABLED` / `VITE_PHASE3_EFFECT_SNOW_ENABLED` / `VITE_PHASE3_EFFECT_FOG_ENABLED` / `VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED`（任意）: 個別エフェクトの rollout フラグ。既定値はすべて `false` で、`VITE_PHASE3_EFFECTS_ENABLED=true` のときにのみ有効。rain / snow / fog / day-night を Phase 3 基盤を残したまま個別にロールバック可能。
-- `VITE_PHASE3_EFFECT_MOTION_ENABLED` / `VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED`（任意）: 移動補間と `current_activity.emoji` ベースの軽量パーティクルの rollout フラグ。既定値 `false`、かつ `VITE_PHASE3_EFFECTS_ENABLED=true` のときのみ有効。段階 rollout / ロールバック時は Phase 1 の静的ノード描画がフォールバックとして残る。
-
-### ローカル検証
 
 ```bash
 cd apps/front
+npm install
 npm run dev
-npm run build
-npm run test:phase1-acceptance
 ```
 
-## Phase 1 受入ゲート
+必須環境変数が欠けていると `npm run dev` / `npm run build` は即座に停止する（fail-fast）。
 
-`npm run test:phase1-acceptance` は観戦 UI の Phase 1 振る舞いに絞った受入ゲート。Unit 28 以降の配信経路転換は Unit 29+ で整理されているが、実務的な UI の go/no-go チェックとしてこのコマンドを使う。
+### 環境変数一覧
 
-自動ゲートが保証する項目：
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `VITE_SNAPSHOT_URL` | ✓ | R2 カスタムドメイン上の snapshot alias URL（既定キー: `snapshot/latest.json`）。ブラウザから直接 fetch する。`http` / `https` のみ、認証情報・クエリ・フラグメント不可 |
+| `VITE_AUTH_MODE` | ✓ | `public` または `access` |
+| `VITE_PHASE3_EFFECTS_ENABLED` | - | エフェクト機能全体の ON/OFF（既定 `false`） |
+| `VITE_PHASE3_EFFECT_RAIN_ENABLED` / `_SNOW_` / `_FOG_` / `_DAY_NIGHT_` | - | 天候・時間帯エフェクトの個別 rollout フラグ（既定 `false`、`VITE_PHASE3_EFFECTS_ENABLED=true` のときのみ有効） |
+| `VITE_PHASE3_EFFECT_MOTION_ENABLED` / `_ACTION_PARTICLES_` | - | 移動補間・`current_activity.emoji` パーティクルの個別 rollout フラグ（既定 `false`、同条件） |
 
-- デスクトップ / モバイル初期シェルが同一 map host を共有して描画される
-- 100 エージェントのスナップショット反映が Phase 1 の 15 秒予算内に収まる
-- history オブジェクトが空 or 劣化していても、選択中エージェント詳細の一貫性が保たれる
-- `history/agents/{agent_id}.json` が取得できる場合は会話ログ展開が加算的に動く
-- stale が quiet period の経過時間ではなく publish health メタデータ（`last_publish_error_at`）で決まり、その後の成功 publish または 3 分 fallback resync で回復できること
-- **Unit 29/32 との整合**: event-driven な snapshot/history 配信を primary とし、静穏期経路は sub-minute heartbeat ではなく **3 分 fallback resync** のみとすること
+history オブジェクト（`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`）は `VITE_SNAPSHOT_URL` と同 origin から派生する。Worker 側に read endpoint はないため `VITE_API_BASE_URL` は不要。
 
-フルスイートは `npm test`、Phase 1 ゲートのみを回すなら `npm run test:phase1-acceptance`。
+## デプロイ手順
 
-## Phase 2 認証モード別デプロイガイド
+### 1. Cloudflare リソースを作成
 
-1 つのデプロイで選べる認証モードは `AUTH_MODE=public` または `AUTH_MODE=access` のいずれか 1 つ。Pages と R2 カスタムドメイン（`snapshot/latest.json` と `history/*` を配信する）が同じモードで構成されたときのみデプロイ成立。
+```bash
+# snapshot / history を同居させる R2 バケット
+npx wrangler r2 bucket create <real-snapshot-bucket>
+npx wrangler r2 bucket create <real-snapshot-bucket-preview>
+```
 
-- `AUTH_MODE=public`: Pages・R2 カスタムドメインがすべて公開。
-- `AUTH_MODE=access`: Pages・R2 カスタムドメインがすべて Cloudflare Access で保護され、ブラウザは snapshot / history オブジェクトを `credentials: 'include'` で fetch する。
+### 2. wrangler.toml を用意
 
-1 デプロイ内でモードを混在させないこと。また `AUTH_MODE=access` の前提が満たされない場合でも Worker/Pages によるスナップショットプロキシをフォールバックとして追加してはならない。Access Cookie の共有 / 事前 seed が確約できない場合は `AUTH_MODE=public` に切り替える。
-
-### R2 カスタムドメインの必須セットアップ
-
-`snapshot_url` は公開 R2 カスタムドメイン上の alias URL（既定値: `https://snapshot.example.com/snapshot/latest.json`）。ブラウザはこのオブジェクトを 5 秒周期で直接 fetch し、history オブジェクト (`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`) も同じ origin から同周期で取得する。
-
-運用側の設定：
-
-1. バケットを Cloudflare カスタムドメイン経由で公開する。
-2. `snapshot/latest.json` と `history/*` の両方に `Cache Everything` の Cache Rule を追加。
-3. それぞれの Edge TTL を `5 seconds` に固定。
-4. オリジン側の `Cache-Control: public, max-age=5` と整合させる。
-5. Pages と R2 カスタムドメインがクロスオリジンなら、`snapshot/*` と `history/*` の両 prefix について Pages オリジンを R2 CORS で許可する。`AUTH_MODE=access` ではさらに `Access-Control-Allow-Credentials: true` を許可。
-
-### `AUTH_MODE=access` の絶対要件
-
-`AUTH_MODE=access` が有効なのは、SPA が `snapshot_url` のポーリングを開始する前に、Pages オリジン・R2 カスタムドメイン双方で利用可能な Access セッションをブラウザが既に持っているときに限る。
-
-- 推奨: Pages と R2 カスタムドメインを 1 つの Access アプリ（または同等の複数ドメインポリシー）配下に置き、1 回ログインで双方の Cookie を事前に seed する。
-- 許容される代替策: R2 カスタムドメイン向け Cookie を明示的に事前 seed する（専用 R2 訪問 / サイレント事前 seed フロー）。
-- 不可: CORS のみに依存する / R2 Access Cookie が無い場合に同一オリジン Worker・Pages のスナップショットプロキシへフォールバックする。
-
-### public/access スモークチェックリスト
-
-デプロイ後・認証モード変更後に必ず実施：
-
-1. デプロイ済み UI を開き、選択モード以外が混在していないこと。
-2. `VITE_SNAPSHOT_URL` を直接ブラウザで叩く：
-   - `AUTH_MODE=public`: Access ログイン無しで 200。
-   - `AUTH_MODE=access`: Pages / R2 双方で Access セッションが確立されてからのみ 200。Pages ログイン済なのに R2 で Access challenge が残る場合はデプロイ未完了。
-3. 返答が R2 カスタムドメイン上の `snapshot/latest.json` から来ていること（Worker には read 系 endpoint が存在しない）。
-4. 同じリクエストを再実行し、`Cache Everything` + `Edge TTL = 5 seconds` により edge キャッシュ HIT（`CF-Cache-Status: HIT` 等）となること。
-5. `history/agents/<known-agent>.json` を同じ R2 origin から直接取得する：
-   - `AUTH_MODE=public`: Access ログイン無しで成功。
-   - `AUTH_MODE=access`: ログイン前は Access challenge / 失敗、ログイン後に成功。
-6. Pages と R2 がクロスオリジンなら、`snapshot/*` と `history/*` の両方について preflight / GET 応答が期待どおりの CORS ヘッダを返し、`AUTH_MODE=access` では `Access-Control-Allow-Credentials: true` と credentialed fetch 成功も確認。
-7. 上記が `AUTH_MODE=access` で満たせない場合は Access Cookie 共有 / 事前 seed を直すか `AUTH_MODE=public` を選択。プロキシフォールバックは禁止。
-
-### 運用側に残る手動チェック項目
-
-以下は staging / preview インフラが必要で、ローカル Vitest だけでは証明できない：
-
-1. **R2 カスタムドメインの edge キャッシュ（両認証モード共通）**
-    - スナップショットオブジェクトパスに `Cache Everything` + `Edge TTL = 5 seconds` を適用。
-    - 同じオブジェクトを 2 回 fetch し、2 回目が edge HIT (`CF-Cache-Status: HIT` 等) になること（cached age は 5 秒 TTL 内）。
-    - TTL 経過後は `generated_at` / `published_at` が更新された新しいボディを返し、鮮度予算を破らないこと。
-
-2. **`AUTH_MODE=access` の Cookie 共有 / 事前 seed**
-    - Pages へのログインが R2 カスタムドメインの Access セッションも確立するか、事前 seed フローが確実に動くこと。
-    - SPA ポーリング前に、ブラウザから `snapshot_url` へ直接 `credentials: 'include'` で fetch して成功すること。
-    - R2 ドメイン側でリダイレクト / challenge が残る場合はデプロイ無効扱い。プロキシ追加禁止。
-
-3. **event-driven primary path + 静穏期フォールバック**
-    - 代表的な world event を発生させ、Worker がそれを history に ingest しつつ更新済み snapshot を速やかに publish することを確認する。readiness の primary path はこの event-driven 配信。
-    - その後デプロイ済 Worker + UI をアイドル状態で開いたままにし、quiet period だけでは stale バナーが出ないことを確認する。代わりに publish health メタデータが失敗を示したときだけ stale が出て、その後の成功 publish または 3 分 fallback resync で解消されることを観測する。
-
-## Cloudflare Worker デプロイ
-
-`wrangler.toml` は git-ignore 済み。トラック済テンプレ `wrangler.toml.example` からローカル生成する：
+`wrangler.toml` は git-ignore 済み。トラック済みテンプレからローカル生成する：
 
 ```bash
 cd apps/front
 cp wrangler.toml.example wrangler.toml
 ```
 
-`wrangler.toml.example` には snapshot/history 共有バケット向けのプレースホルダ R2 バケット名が入っている：
+`wrangler.toml` 内のプレースホルダ R2 バケット名（`replace-with-real-snapshot-bucket` / `...-preview`）を、作成した実バケット名に書き換える。
 
-- `bucket_name = "replace-with-real-snapshot-bucket"`
-- `preview_bucket_name = "replace-with-real-snapshot-bucket-preview"`
-
-本番デプロイ前に、スナップショットオブジェクトと history オブジェクトの両方を保存する R2 バケットを作成または特定し、ローカル `wrangler.toml` の値を実名へ置き換える。
-
-例：
-
-```bash
-cd apps/front
-npx wrangler r2 bucket create <real-snapshot-bucket>
-npx wrangler r2 bucket create <real-snapshot-bucket-preview>
-```
-
-その後、必要なシークレット（初回のみ）を設定してからデプロイ：
+### 3. シークレットを設定（初回のみ）
 
 ```bash
 npx wrangler secret put SNAPSHOT_PUBLISH_AUTH_KEY
+```
+
+`SNAPSHOT_PUBLISH_AUTH_KEY` は本体サーバー（`@karakuri-world/server`）が `/api/publish-snapshot` / `/api/publish-agent-history` を叩くときに使う共有 Bearer トークン。本体側 `.env` の同名変数と完全一致させる。空文字・空白のみは Worker 起動時の env parse で失敗するので不可。未設定なら publish endpoint は default-deny の `503` のままとなる。
+
+対話式デバッグフロー（`npm run debug:start`）でも同じ secret を入力する。
+
+### 4. R2 バケットの CORS を設定
+
+Pages ドメインと R2 カスタムドメインがクロスオリジンの場合、`snapshot/*` と `history/*` の両 prefix について Pages オリジンを許可する：
+
+```bash
+cat > /tmp/cors.json << 'EOF'
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": ["https://your-pages-domain.example.com"],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "maxAgeSeconds": 86400
+    }
+  ]
+}
+EOF
+npx wrangler r2 bucket cors set <real-snapshot-bucket> --file /tmp/cors.json
+```
+
+`origins` は実際の Pages ドメインに書き換える。`AUTH_MODE=access` ではさらに `Access-Control-Allow-Credentials: true` も許可する必要がある。設定確認は `npx wrangler r2 bucket cors list <real-snapshot-bucket>`。
+
+### 5. Worker をデプロイ
+
+```bash
 npm run deploy:prod
 ```
 
-対話式デバッグフロー（`npm run debug:start`）でも、同じ 2 つの Worker secret を入力するようになった。`SNAPSHOT_PUBLISH_AUTH_KEY` には本体サーバーで使っている値と同じ共有キーを設定すること。空文字は不可で、未設定なら Worker の `/api/publish-snapshot` / `/api/publish-agent-history` は default-deny の `503` のまま、空文字・空白だけの secret を設定した場合は Worker 起動時の env parse で失敗する。
-
 `deploy:prod` は以下を順に実行するラッパ：
 
-1. `wrangler.toml` にプレースホルダ R2 バケット名が残っていたら fail-closed で停止。
-2. `npx wrangler deploy` でデプロイ。
-3. Worker URL に対して 1 回 `curl` を打ち、`UIBridgeDurableObject.boot()` を即時起動して静穏期 alarm 経路を立ち上げる。
+1. `wrangler.toml` にプレースホルダ R2 バケット名が残っていたら fail-closed で停止
+2. `npx wrangler deploy` でデプロイ
+3. Worker URL に対して 1 回 `curl` を打ち、`UIBridgeDurableObject.boot()` を即時起動して静穏期 alarm 経路を立ち上げる
 
-最低限、バックエンドが `/api/publish-snapshot` / `/api/publish-agent-history` を叩くときに使う共有シークレット `SNAPSHOT_PUBLISH_AUTH_KEY` が必要。Worker 側には read endpoint が無くなったので `HISTORY_CORS_ALLOWED_ORIGINS` の設定は不要。
+> **注意**: 3 のウォームアップが成功しないと静穏期 fallback resync が始まらない。
 
-共有 R2 バケットには snapshot alias (`snapshot/latest.json`) と history オブジェクト（`history/agents/{agent_id}.json`、`history/conversations/{conversation_id}.json`）が同居し、観戦 UI は R2 カスタムドメインから直接読む。
+### 6. フロントエンドをデプロイ（Cloudflare Pages）
 
-## Relay アラート配線と readiness ゲート
-
-Unit 32 で relay `/ws` は primary path から外れ、バックエンドの legacy `/ws` endpoint も削除済み。Worker 側も `/ws` を Durable Object fallback に流さず `404` で fail-close する。readiness は polling + R2/CDN の鮮度、alias オブジェクト（snapshot / history 双方）への直接 fetch、event-driven な snapshot/history 配信、認証モードの整合性を中心に構成され、静穏期に残る periodic path は 3 分 fallback resync のみ。relay アラート成果物（`relay-alerting-spec.json` 等）は `ui.*` と `relay.r2.*` シグナルだけをカバーし、relay WebSocket シグナルは残っていない。
-
-リポジトリ管理の正本成果物：
-
-- `worker/ops/relay-alerting-spec.json`: アラートルール / 配信ルート / clear 条件 / 認証系とネットワーク系のルート分割。
-- `worker/ops/relay-synthetic-drills.json`: staging ドリルカタログ＋期待アラート経路に到達する合成メトリックタイムライン。
-- `worker/ops/relay-production-readiness.template.json`: 本番 sign-off テンプレ（実ルート / 受信ログ / ドリル証跡 / sign-off 時刻が埋まるまで fail-closed）。
-- `worker/ops/relay-production-readiness.example.json`: レビュー / テスト用の passing 例。
-
-検証コマンド：
+`.env.local` の `VITE_*` 変数をセットしてからビルド・デプロイ：
 
 ```bash
-cd apps/front
-npm run relay:readiness
-npm run relay:readiness -- --target=production --manifest worker/ops/relay-production-readiness.example.json --wrangler worker/test/fixtures/wrangler.production.example.toml
+npm run build
+npx wrangler pages deploy dist --project-name karakuri-world-ui-frontend \
+  --commit-dirty=true --commit-message="deploy"
 ```
 
-`npm run relay:readiness` 単体はリポ内カタログ / ドリル成果物を検証。primary の event-driven + 静穏期 fallback / R2 readiness は上記手動チェック＋ Unit 29+ の手順が別途必要。本番 relay 検証は manifest が埋まるまで fail-closed のまま。
+## 認証モード
+
+1 デプロイで選べるのは `AUTH_MODE=public` または `AUTH_MODE=access` のいずれか 1 つ。Pages と R2 カスタムドメイン（`snapshot/latest.json` と `history/*` を配信する）が同じモードで構成されたときのみデプロイ成立。
+
+### `AUTH_MODE=public`（推奨・シンプル）
+
+Pages・R2 カスタムドメインがすべて公開アクセス可能。
+
+### `AUTH_MODE=access`
+
+Pages と R2 カスタムドメインを 1 つの Access アプリ（または同等の複数ドメインポリシー）配下に置き、1 回ログインで双方の Cookie を事前に seed する構成が前提。ブラウザは snapshot / history オブジェクトを `credentials: 'include'` で fetch する。
+
+Access Cookie の共有 / 事前 seed が確約できない場合は、Worker/Pages でのスナップショットプロキシをフォールバックとして追加してはならない。代わりに `AUTH_MODE=public` へ切り替える。
+
+## デプロイ後の確認
+
+1. `VITE_SNAPSHOT_URL` をブラウザで直接開き、JSON が返ること（`AUTH_MODE=access` では Access セッション確立後のみ 200）
+2. 同じ URL を再 fetch し、`Cache Everything` + `Edge TTL = 5 seconds` により `CF-Cache-Status: HIT` になること
+3. `history/agents/<known-agent>.json` を同じ R2 origin から直接取得できること
+4. Pages と R2 がクロスオリジンなら、`snapshot/*` と `history/*` の preflight / GET に期待どおりの CORS ヘッダが付き、`AUTH_MODE=access` では `Access-Control-Allow-Credentials: true` と credentialed fetch 成功も確認
+5. UI を開いてスナップショットが定期更新されていること（publish-health メタデータが失敗を示さない限り stale バナーが出ないこと、出た場合も成功 publish か 3 分 fallback resync で解消されること）
+
+`AUTH_MODE=access` で上記が満たせない場合は Access Cookie 共有 / 事前 seed を直すか `AUTH_MODE=public` を選択。プロキシフォールバックは禁止。
+
+## R2 キャッシュ設定
+
+Cloudflare ダッシュボードで `snapshot/latest.json` と `history/*` の両方に Cache Rule を追加する：
+
+- **ルール**: `Cache Everything`
+- **Edge TTL**: `5 seconds`
+
+R2 側のオブジェクトには `Cache-Control: public, max-age=5` を設定し、オリジンと edge の TTL を揃える。
+
+## テスト
+
+```bash
+npm test                       # フルスイート
+npm run test:phase1-acceptance # Phase 1 受入ゲートのみ
+npm run relay:readiness        # relay アラート設定の検証
+```
+
+`npm run test:phase1-acceptance` は観戦 UI の Phase 1 go/no-go チェックで、以下を保証する：
+
+- デスクトップ / モバイル初期シェルが同一 map host を共有して描画される
+- 100 エージェントのスナップショット反映が Phase 1 の 15 秒予算内に収まる
+- history オブジェクトが空 / 劣化していても選択中エージェント詳細の一貫性が保たれる
+- `history/agents/{agent_id}.json` があれば会話ログ展開が加算的に動く
+- stale は publish-health メタデータ（`last_publish_error_at`）で決まり、成功 publish または 3 分 fallback resync で回復する
+- event-driven な snapshot/history 配信を primary とし、静穏期経路は sub-minute heartbeat ではなく 3 分 fallback resync のみ
+
+## Relay readiness ゲート
+
+Unit 32 で relay `/ws` は primary path から外れ、バックエンドの legacy `/ws` endpoint も削除済み。Worker 側も `/ws` を `404` で fail-close する。readiness は polling + R2/CDN 鮮度、alias オブジェクト（snapshot / history 双方）への直接 fetch、event-driven な publish、認証モード整合性で構成され、静穏期経路は 3 分 fallback resync のみ。relay アラート成果物は `ui.*` / `relay.r2.*` シグナルに限定される（relay WebSocket シグナルは残っていない）。
 
 relay ゲートが満たすべき条件：
 
-- readiness アラートは Unit 10/29+ の primary メトリクスセットを使う: `ui.snapshot.refresh_failure_total{reason}`、`ui.snapshot.generated_age_ms`、`ui.snapshot.published_age_ms`、`ui.r2.publish_failure_total`、`ui.r2.publish_failure_streak`。
-- `ui.snapshot.refresh_failure_total{reason}` の `reason` には、Phase 8 の Worker が実際に emit する `boot` / `fallback-refresh` / `world-event` / `manual` / `external-request` を使う。
-- sustained outage の pager ルートが実本番配信先に解決できること。
-- R2 retry brake 飽和（`ui.r2.publish_failure_streak >= 5`、60 秒 cap に合致）が明示ゲート項目。
-- 即時（auth/config）pager ルートと sustained outage pager ルートは別の本番配信先に解決されること。
-- 本番 manifest は実通知先 / provider ルール参照 / 要求される全アラート経路の staging ドリル証跡（observed alert ID & observed route ID）/ 事前 sign-off を含むこと。
-- `wrangler.toml` に必須の `SNAPSHOT_BUCKET` バインドが無い、またはプレースホルダ R2 のままの場合も本番検証は失敗扱い。
+- readiness アラートは primary メトリクスセット `ui.snapshot.refresh_failure_total{reason}` / `ui.snapshot.generated_age_ms` / `ui.snapshot.published_age_ms` / `ui.r2.publish_failure_total` / `ui.r2.publish_failure_streak` を使う
+- `ui.snapshot.refresh_failure_total{reason}` の `reason` は Worker が実際に emit する `boot` / `fallback-refresh` / `world-event` / `manual` / `external-request` を使う
+- R2 retry brake 飽和（`ui.r2.publish_failure_streak >= 5`、60 秒 cap）が明示ゲート項目
+- 即時（auth/config）pager ルートと sustained outage pager ルートは別の本番配信先に解決されること
+- 本番 manifest は実通知先 / provider ルール参照 / 要求される全アラート経路の staging ドリル証跡 / 事前 sign-off を含むこと
+- `wrangler.toml` に必須の `SNAPSHOT_BUCKET` バインドが無い、またはプレースホルダ R2 のままの場合は本番検証失敗
+
+`npm run relay:readiness` 単体はリポ内カタログ / ドリル成果物のみ検証。本番 relay 検証は manifest が埋まるまで fail-closed のまま。
+
+## 運用ファイル
+
+| ファイル | 用途 |
+|---------|------|
+| `worker/ops/relay-alerting-spec.json` | アラートルール / 配信ルート / clear 条件 |
+| `worker/ops/relay-synthetic-drills.json` | staging ドリルカタログ＋合成メトリックタイムライン |
+| `worker/ops/relay-production-readiness.template.json` | 本番 sign-off テンプレ（fail-closed） |
+| `worker/ops/relay-production-readiness.example.json` | レビュー / テスト用の passing 例 |

--- a/apps/front/README.md
+++ b/apps/front/README.md
@@ -2,191 +2,188 @@
 
 > 日本語版は [README.ja.md](./README.ja.md) を参照。
 
-This package contains the spectator SPA (`app/`) and the Cloudflare Worker relay (`worker/`). It is the `apps/front/` workspace of the Karakuri World monorepo. Run all commands below from inside `apps/front/`, or invoke them from the repo root with `npm run dev:front` / `npm run build:front` / `npm test -w @karakuri-world/front`.
+Spectator UI. Two-layer architecture: Vite/React SPA (Cloudflare Pages) + Cloudflare Worker (Durable Object that publishes snapshot and history objects), shipped as the `apps/front/` workspace of the Karakuri World monorepo.
 
-## Spectator UI dev/build environment
+Run the commands below from inside `apps/front/`, or invoke them from the repo root with `npm run dev:front` / `npm run build:front` / `npm test -w @karakuri-world/front`.
 
-The Vite app is fail-fast by design: both `npm run dev` and `npm run build` stop immediately unless all required browser-side variables are present.
+## Local development
 
-Create `apps/front/.env.local` (or another Vite env file) with:
+Create `.env.local`, then start the dev server:
 
 ```bash
-VITE_SNAPSHOT_URL=https://snapshots.example.com/snapshot/latest.json
+VITE_SNAPSHOT_URL=https://snapshot.example.com/snapshot/latest.json
 VITE_AUTH_MODE=public
-VITE_PHASE3_EFFECTS_ENABLED=false
-VITE_PHASE3_EFFECT_RAIN_ENABLED=false
-VITE_PHASE3_EFFECT_SNOW_ENABLED=false
-VITE_PHASE3_EFFECT_FOG_ENABLED=false
-VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED=false
-VITE_PHASE3_EFFECT_MOTION_ENABLED=false
-VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED=false
 ```
-
-Required values:
-
-- `VITE_SNAPSHOT_URL`: absolute browser-fetchable snapshot alias URL (the R2/CDN `snapshot/latest.json`). The browser polls this object every 5 seconds and the edge caches it with `Cache-Control: public, max-age=5`. Because this value ships in the browser bundle, it must stay public-facing: use only `http` / `https`, and do not embed credentials, query params, or fragments. The history object URLs (`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`) are derived from the same origin.
-- `VITE_AUTH_MODE`: `public` or `access`.
-- `VITE_PHASE3_EFFECTS_ENABLED` (optional): `true` or `false`. Defaults to `false`; keep it off until Phase 3 effects are intentionally being exercised.
-- `VITE_PHASE3_EFFECT_RAIN_ENABLED`, `VITE_PHASE3_EFFECT_SNOW_ENABLED`, `VITE_PHASE3_EFFECT_FOG_ENABLED`, `VITE_PHASE3_EFFECT_DAY_NIGHT_ENABLED` (optional): per-effect rollout flags. Each defaults to `false`, and each only takes effect when `VITE_PHASE3_EFFECTS_ENABLED=true`, so rain / snow / fog / day-night can be rolled back independently without removing the Phase 3 foundation.
-- `VITE_PHASE3_EFFECT_MOTION_ENABLED`, `VITE_PHASE3_EFFECT_ACTION_PARTICLES_ENABLED` (optional): rollout flags for movement interpolation and lightweight `current_activity.emoji` particles. Both default to `false`, and both only take effect when `VITE_PHASE3_EFFECTS_ENABLED=true`, so Phase 1 static node rendering remains the fallback during staged rollout or rollback.
-
-For local verification:
 
 ```bash
 cd apps/front
+npm install
 npm run dev
-npm run build
-npm run test:phase1-acceptance
 ```
 
-## Phase 1 acceptance gate
+`npm run dev` / `npm run build` stop immediately if any required variable is missing (fail-fast).
 
-`npm run test:phase1-acceptance` is the focused acceptance gate for the spectator UI Phase 1 behavior. The updated delivery-track pivot after Unit 28 is documented in Units 29+; this command remains the practical UI go/no-go check.
+### Environment variables
 
-The automated gate covers:
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VITE_SNAPSHOT_URL` | ✓ | Snapshot alias URL on the R2 custom domain (default key: `snapshot/latest.json`). Fetched directly by the browser. `http` / `https` only; no credentials, query, or fragment |
+| `VITE_AUTH_MODE` | ✓ | `public` or `access` |
+| `VITE_PHASE3_EFFECTS_ENABLED` | - | Master switch for Phase 3 visual effects (default `false`) |
+| `VITE_PHASE3_EFFECT_RAIN_ENABLED` / `_SNOW_` / `_FOG_` / `_DAY_NIGHT_` | - | Per-effect rollout flags for weather / day-night (default `false`; effective only when `VITE_PHASE3_EFFECTS_ENABLED=true`) |
+| `VITE_PHASE3_EFFECT_MOTION_ENABLED` / `_ACTION_PARTICLES_` | - | Rollout flags for movement interpolation and `current_activity.emoji` particles (default `false`; same condition) |
 
-- desktop + mobile initial shell layout on one shared map host
-- 100-agent snapshot reflection within the Phase 1 15-second budget
-- selected agent detail remains coherent even when the history object is empty or degraded
-- populated agent history fetches (`history/agents/{agent_id}.json`) and conversation log expansion are additive comparisons when ingest/backfill is available
-- stale signaling driven by publish-health metadata (`last_publish_error_at`) rather than quiet periods alone, while later successful publishes or the 3-minute fallback resync clear the banner
-- **Units 29/32 alignment**: event-driven snapshot/history publication is the primary freshness path, and the quiet-period path is only the **3-minute fallback resync**, not a sub-minute heartbeat
+History objects (`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`) are derived from the same origin as `VITE_SNAPSHOT_URL`. The Worker exposes no read-side endpoints, so `VITE_API_BASE_URL` is not needed.
 
-Run the full suite with `npm test`; use `npm run test:phase1-acceptance` when you want the Phase 1 go/no-go gate only.
+## Deployment
 
-## Phase 2 auth-mode deployment guide
+### 1. Create Cloudflare resources
 
-Choose exactly one auth mode per deployment: `AUTH_MODE=public` or `AUTH_MODE=access`. A deployment is valid only when Pages and the R2 custom domain (serving both `snapshot/latest.json` and `history/*`) are configured for that same mode.
+```bash
+# R2 buckets holding both snapshot and history objects
+npx wrangler r2 bucket create <real-snapshot-bucket>
+npx wrangler r2 bucket create <real-snapshot-bucket-preview>
+```
 
-- `AUTH_MODE=public`: Pages and the R2 custom domain are all publicly reachable.
-- `AUTH_MODE=access`: Pages and the R2 custom domain are protected by Cloudflare Access, and the browser fetches snapshot and history objects with `credentials: 'include'`.
+### 2. Prepare wrangler.toml
 
-Do not mix modes within one deployment, and do not add a Worker/Pages snapshot proxy fallback when `AUTH_MODE=access` preconditions are not met. If Access cookie sharing or pre-seeding cannot be guaranteed, switch the deployment to `AUTH_MODE=public`.
-
-### Required R2 custom-domain setup
-
-`snapshot_url` is the public alias URL on the R2 custom domain (default: `https://snapshot.example.com/snapshot/latest.json`). The browser fetches this object directly every 5 seconds, and history documents (`history/agents/{agent_id}.json` / `history/conversations/{conversation_id}.json`) are fetched from the same origin on the same cadence.
-
-Required operator setup on the R2 custom domain:
-
-1. Publish the bucket through a Cloudflare custom domain.
-2. Add Cache Rules with `Cache Everything` on both `snapshot/latest.json` and `history/*`.
-3. Fix the Edge TTL to `5 seconds` for each rule.
-4. Keep those rules aligned with the origin `Cache-Control: public, max-age=5`.
-5. If Pages and the R2 custom domain are cross-origin, configure R2 CORS so the Pages origin is allowed for both `snapshot/*` and `history/*` in both auth modes. For `AUTH_MODE=access`, also allow credentialed fetches (`Access-Control-Allow-Credentials: true`).
-
-### `AUTH_MODE=access` hard preconditions
-
-`AUTH_MODE=access` is valid only when the browser already has a usable Access session for both the Pages origin and the R2 custom domain before the SPA starts polling `snapshot_url`.
-
-- Preferred: place Pages and the R2 custom domain behind one Access app or an equivalent multi-domain policy so one login pre-seeds both cookies.
-- Acceptable alternative: explicitly pre-seed the R2 custom-domain cookie before the SPA starts (for example via a dedicated R2 visit / silent pre-seeding flow).
-- Not acceptable: relying on CORS alone, or falling back to a same-origin Worker/Pages snapshot proxy when R2 Access cookies are missing.
-
-### Public/access smoke-test checklist
-
-Run the following after each deployment or auth-mode change:
-
-1. Open the deployed UI and confirm the chosen mode is the only mode in use for that deployment.
-2. Request `VITE_SNAPSHOT_URL` directly in the browser:
-   - `AUTH_MODE=public`: expect HTTP 200 without Access login.
-   - `AUTH_MODE=access`: expect HTTP 200 only after Pages and R2 Access sessions are both established; if R2 still challenges while Pages is already logged in, the deployment is not ready.
-3. Verify the snapshot response comes from the R2 custom domain (`snapshot/latest.json`); the Worker exposes no read-side endpoints.
-4. Repeat the snapshot request and confirm edge caching (`CF-Cache-Status: HIT` or equivalent) with the `Cache Everything` + `Edge TTL = 5 seconds` rule in effect.
-5. Request `history/agents/<known-agent>.json` from the same R2 origin:
-   - `AUTH_MODE=public`: expect success without Access login.
-   - `AUTH_MODE=access`: expect an Access auth challenge/failure before login, then success after the Access session is established.
-6. If Pages and R2 are cross-origin, confirm the R2 response includes the expected CORS behavior for the Pages origin on both `snapshot/*` and `history/*`, and for `AUTH_MODE=access` also confirm `Access-Control-Allow-Credentials: true` and a successful credentialed fetch.
-7. If any of the above fails in `AUTH_MODE=access`, fix Access cookie sharing / pre-seeding or choose `AUTH_MODE=public`; do not ship a proxy fallback.
-
-### Manual acceptance items that still require an operator
-
-The following checks still need staging/preview infrastructure and cannot be fully proven in local Vitest alone:
-
-1. **R2 custom-domain edge cache (`AUTH_MODE=public` or `AUTH_MODE=access`)**
-    - Apply `Cache Everything` + `Edge TTL = 5 seconds` on the snapshot object path served from the R2 custom domain.
-    - Request the same snapshot object twice and confirm the second response becomes an edge cache hit (`CF-Cache-Status: HIT` or equivalent) while the cached age stays within the 5-second TTL window.
-    - After the TTL rolls over, confirm the object serves a newer body with updated `generated_at` / `published_at` without breaking the freshness budget.
-
-2. **`AUTH_MODE=access` cookie sharing / pre-seeding**
-   - Confirm Pages login also establishes an R2 custom-domain Access session, or run the documented pre-seeding flow before the SPA begins polling.
-   - Verify the first direct browser fetch to `snapshot_url` succeeds with `credentials: 'include'`.
-   - If the first fetch still redirects/challenges on the R2 domain, treat the deployment as invalid rather than adding a snapshot proxy.
-
-3. **Event-driven primary path + quiet-period fallback**
-    - Trigger representative world events and confirm the worker ingests them into history and publishes an updated snapshot promptly; event-driven publication is the primary readiness path.
-    - Then, with the deployed worker and UI left idle, confirm healthy quiet periods do **not** trigger the stale banner on age alone; instead, verify the banner appears only when publish-health metadata reports a failure and clears after a later successful publish or fallback resync.
-
-## Cloudflare Worker deployment
-
-`wrangler.toml` is git-ignored and must be generated locally from the tracked template `wrangler.toml.example`:
+`wrangler.toml` is git-ignored and must be generated locally from the tracked template:
 
 ```bash
 cd apps/front
 cp wrangler.toml.example wrangler.toml
 ```
 
-`wrangler.toml.example` carries placeholder R2 bucket names for the shared snapshot/history bucket:
+Replace the placeholder R2 bucket names (`replace-with-real-snapshot-bucket` / `...-preview`) in `wrangler.toml` with the real buckets you just created.
 
-- `bucket_name = "replace-with-real-snapshot-bucket"`
-- `preview_bucket_name = "replace-with-real-snapshot-bucket-preview"`
-
-Before any real deploy, create or identify the bucket that will hold both snapshot objects and history objects, then replace those values in your local `wrangler.toml`.
-
-Example:
-
-```bash
-cd apps/front
-npx wrangler r2 bucket create <real-snapshot-bucket>
-npx wrangler r2 bucket create <real-snapshot-bucket-preview>
-```
-
-Then set required secrets (once) and deploy:
+### 3. Set secrets (first time only)
 
 ```bash
 npx wrangler secret put SNAPSHOT_PUBLISH_AUTH_KEY
+```
+
+`SNAPSHOT_PUBLISH_AUTH_KEY` is the shared Bearer token the backend (`@karakuri-world/server`) uses when calling `/api/publish-snapshot` and `/api/publish-agent-history`. It must match the same-named variable in the backend `.env` exactly. Empty or whitespace-only values fail the Worker env parse at boot; leaving it unset keeps those publish endpoints in the default-deny `503` state.
+
+The interactive debug flow (`npm run debug:start`) prompts for the same secret.
+
+### 4. Configure R2 bucket CORS
+
+When the Pages domain and the R2 custom domain are cross-origin, allow the Pages origin for both the `snapshot/*` and `history/*` prefixes:
+
+```bash
+cat > /tmp/cors.json << 'EOF'
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": ["https://your-pages-domain.example.com"],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "maxAgeSeconds": 86400
+    }
+  ]
+}
+EOF
+npx wrangler r2 bucket cors set <real-snapshot-bucket> --file /tmp/cors.json
+```
+
+Replace `origins` with your actual Pages domain. For `AUTH_MODE=access`, also allow `Access-Control-Allow-Credentials: true`. Verify with `npx wrangler r2 bucket cors list <real-snapshot-bucket>`.
+
+### 5. Deploy the Worker
+
+```bash
 npm run deploy:prod
 ```
 
-For the interactive debug flow (`npm run debug:start`), the script now prompts for both Worker secrets as well. Enter the same `SNAPSHOT_PUBLISH_AUTH_KEY` value that your backend uses. It must be non-empty: leaving it unset keeps the Worker's `/api/publish-snapshot` and `/api/publish-agent-history` endpoints in the default-deny `503` state, and configuring it as an empty/blank secret now fails Worker env parsing during boot.
-
 `deploy:prod` wraps the following steps:
 
-1. Fail closed if `wrangler.toml` still contains placeholder R2 bucket names.
-2. Run `npx wrangler deploy`.
-3. `curl` the Worker URL once so `UIBridgeDurableObject.boot()` runs immediately and starts the quiet-period alarm path.
+1. Fail closed if `wrangler.toml` still contains placeholder R2 bucket names
+2. Run `npx wrangler deploy`
+3. `curl` the Worker URL once so `UIBridgeDurableObject.boot()` runs immediately and starts the quiet-period alarm path
 
-At minimum, deployment requires the shared publish secret `SNAPSHOT_PUBLISH_AUTH_KEY` used by the backend when calling `/api/publish-snapshot` and `/api/publish-agent-history`. The Worker no longer serves any read-side `/api/history` endpoint, so `HISTORY_CORS_ALLOWED_ORIGINS` is not required.
+> **Note**: If step 3 does not succeed, the quiet-period fallback resync will not start.
 
-The shared R2 bucket stores the snapshot alias (`snapshot/latest.json`) alongside history objects (`history/agents/{agent_id}.json` and `history/conversations/{conversation_id}.json`). Observer UIs read these objects directly from the R2 custom domain.
+### 6. Deploy the frontend (Cloudflare Pages)
 
-## Relay alert wiring and readiness gate
-
-Unit 32 removed relay `/ws` as a primary path, and the backend has now removed the legacy `/ws` endpoint entirely. The Worker now fail-closes `/ws` with `404` instead of falling through any Durable Object fallback. The readiness story is polling + R2/CDN freshness, direct alias-object fetches for both snapshot and history, event-driven snapshot/history publication, and auth-mode correctness, with only the 3-minute quiet-period fallback resync remaining. The relay alert artifacts (`relay-alerting-spec.json` etc.) cover `ui.*` and `relay.r2.*` signals only — no relay WebSocket signals remain.
-
-Authoritative repo-owned artifacts:
-
-- `worker/ops/relay-alerting-spec.json`: alert rules, routes, clear conditions, and the required auth-vs-network routing split.
-- `worker/ops/relay-synthetic-drills.json`: staging drill catalog plus synthetic metric timelines that must evaluate into the expected alert paths.
-- `worker/ops/relay-production-readiness.template.json`: production sign-off template that intentionally fails the gate until real routes, receipts, drill evidence, and sign-off timestamps are filled in.
-- `worker/ops/relay-production-readiness.example.json`: passing example manifest shape for review/tests.
-
-Validation commands:
+Set the `VITE_*` variables in `.env.local`, then build and deploy:
 
 ```bash
-cd apps/front
-npm run relay:readiness
-npm run relay:readiness -- --target=production --manifest worker/ops/relay-production-readiness.example.json --wrangler worker/test/fixtures/wrangler.production.example.toml
+npm run build
+npx wrangler pages deploy dist --project-name karakuri-world-ui-frontend \
+  --commit-dirty=true --commit-message="deploy"
 ```
 
-`npm run relay:readiness` by itself validates the checked-in catalog/drill artifacts. Primary event-driven + quiet-period fallback/R2 readiness still requires the separate operator checks documented above and in Units 29+; production relay validation remains fail-closed until the production manifest is filled in.
+## Auth modes
+
+Pick exactly one mode per deployment: `AUTH_MODE=public` or `AUTH_MODE=access`. A deployment is valid only when Pages and the R2 custom domain (serving both `snapshot/latest.json` and `history/*`) are configured for the same mode.
+
+### `AUTH_MODE=public` (recommended — simple)
+
+Pages and the R2 custom domain are all publicly accessible.
+
+### `AUTH_MODE=access`
+
+Pages and the R2 custom domain must sit behind one Access app (or an equivalent multi-domain policy) so a single login pre-seeds cookies for both. The browser fetches snapshot and history objects with `credentials: 'include'`.
+
+If Access cookie sharing / pre-seeding cannot be guaranteed, do **not** add a Worker/Pages snapshot proxy fallback. Switch to `AUTH_MODE=public` instead.
+
+## Post-deploy verification
+
+1. Open `VITE_SNAPSHOT_URL` directly in a browser and confirm JSON is returned (for `AUTH_MODE=access`, expect HTTP 200 only after the Access session is established).
+2. Repeat the snapshot request and confirm edge caching (`CF-Cache-Status: HIT` or equivalent) with the `Cache Everything` + `Edge TTL = 5 seconds` rule in effect.
+3. Request `history/agents/<known-agent>.json` from the same R2 origin and confirm it loads.
+4. When Pages and R2 are cross-origin, confirm both `snapshot/*` and `history/*` preflight / GET responses carry the expected CORS headers. For `AUTH_MODE=access`, also confirm `Access-Control-Allow-Credentials: true` and a successful credentialed fetch.
+5. Open the UI and confirm snapshots refresh periodically — the stale banner must not appear while publish-health metadata is healthy, and it must clear after a later successful publish or the 3-minute fallback resync.
+
+If any of the above fails in `AUTH_MODE=access`, fix Access cookie sharing / pre-seeding or choose `AUTH_MODE=public`. Do not ship a proxy fallback.
+
+## R2 cache configuration
+
+Add Cache Rules in the Cloudflare dashboard for both `snapshot/latest.json` and `history/*`:
+
+- **Rule**: `Cache Everything`
+- **Edge TTL**: `5 seconds`
+
+Set `Cache-Control: public, max-age=5` on the R2 objects so origin and edge TTLs line up.
+
+## Testing
+
+```bash
+npm test                       # full suite
+npm run test:phase1-acceptance # Phase 1 acceptance gate only
+npm run relay:readiness        # relay alert configuration validation
+```
+
+`npm run test:phase1-acceptance` is the focused go/no-go gate for the spectator UI. It covers:
+
+- desktop + mobile initial shell layout on one shared map host
+- 100-agent snapshot reflection within the Phase 1 15-second budget
+- selected agent detail remains coherent when history objects are empty or degraded
+- populated `history/agents/{agent_id}.json` fetches make conversation log expansion additive
+- stale signaling driven by publish-health metadata (`last_publish_error_at`), cleared by later successful publishes or the 3-minute fallback resync
+- event-driven snapshot/history publication as the primary freshness path, with only the 3-minute fallback resync remaining during quiet periods (no sub-minute heartbeat)
+
+## Relay readiness gate
+
+Unit 32 removed relay `/ws` as a primary path, and the backend has now removed the legacy `/ws` endpoint entirely. The Worker fail-closes `/ws` with `404`. Readiness is polling + R2/CDN freshness, direct alias-object fetches for both snapshot and history, event-driven publication, and auth-mode correctness, with only the 3-minute quiet-period fallback resync remaining. The relay alert artifacts cover `ui.*` and `relay.r2.*` signals only — no relay WebSocket signals remain.
 
 Relay gate expectations:
 
-- readiness alerts use the primary metric set from Units 10/29+: `ui.snapshot.refresh_failure_total{reason}`, `ui.snapshot.generated_age_ms`, `ui.snapshot.published_age_ms`, `ui.r2.publish_failure_total`, and `ui.r2.publish_failure_streak`.
-- `ui.snapshot.refresh_failure_total{reason}` now uses the Phase 8 refresh reasons emitted by the Worker: `boot`, `fallback-refresh`, `world-event`, `manual`, and `external-request`.
-- the sustained outage pager route must resolve to a real production destination.
-- R2 retry-brake saturation (`ui.r2.publish_failure_streak >= 5`, matching the 60-second cap) is an explicit gate item.
-- the immediate auth/config pager route and the sustained outage pager route must resolve to different production destinations.
-- the production manifest must include real notification destinations, provider rule references, staging drill receipts with both observed alert IDs and observed route IDs for every required alert path, and pre-production sign-off.
-- production validation also fails if `wrangler.toml` omits the required `SNAPSHOT_BUCKET` binding or still has placeholder R2 bucket names.
+- readiness alerts use the primary metric set: `ui.snapshot.refresh_failure_total{reason}`, `ui.snapshot.generated_age_ms`, `ui.snapshot.published_age_ms`, `ui.r2.publish_failure_total`, `ui.r2.publish_failure_streak`
+- `ui.snapshot.refresh_failure_total{reason}` uses the reasons emitted by the Worker: `boot`, `fallback-refresh`, `world-event`, `manual`, `external-request`
+- R2 retry-brake saturation (`ui.r2.publish_failure_streak >= 5`, matching the 60-second cap) is an explicit gate item
+- the immediate auth/config pager route and the sustained outage pager route must resolve to different production destinations
+- the production manifest must include real notification destinations, provider rule references, staging drill receipts for every required alert path, and pre-production sign-off
+- production validation also fails if `wrangler.toml` omits the required `SNAPSHOT_BUCKET` binding or still has placeholder R2 bucket names
+
+`npm run relay:readiness` by itself validates only the checked-in catalog/drill artifacts. Production relay validation remains fail-closed until the production manifest is filled in.
+
+## Operations files
+
+| File | Purpose |
+|------|---------|
+| `worker/ops/relay-alerting-spec.json` | Alert rule definitions, routes, and clear conditions |
+| `worker/ops/relay-synthetic-drills.json` | Staging drill catalog plus synthetic metric timelines |
+| `worker/ops/relay-production-readiness.template.json` | Production sign-off template (fail-closed) |
+| `worker/ops/relay-production-readiness.example.json` | Passing example manifest for review/tests |

--- a/apps/server/README.ja.md
+++ b/apps/server/README.ja.md
@@ -1,0 +1,296 @@
+# @karakuri-world/server
+
+Karakuri World のワールドサーバー本体。REST API・MCP・Discord Bot・管理 API・観戦 UI 向け snapshot/history publisher を同梱する。Karakuri World モノレポの `apps/server/` workspace にあたる。
+
+以下のコマンドは `apps/server/` 内で実行するか、リポジトリルートから `npm run dev:server` / `npm run build:server` / `npm start` / `npm test -w @karakuri-world/server` で叩く。
+
+## セットアップ
+
+### 1. 依存関係を入れる
+
+ルートで一度叩けば両 workspace ぶん入る：
+
+```bash
+npm install
+```
+
+### 2. 環境変数を用意する
+
+```bash
+cp apps/server/.env.example apps/server/.env
+```
+
+`apps/server/.env` を編集する。
+
+| 変数 | 必須 | 説明 |
+|------|------|------|
+| `ADMIN_KEY` | ✓ | 管理 API 用。`X-Admin-Key` ヘッダで送る |
+| `DISCORD_TOKEN` | ✓ | World Bot の Bot Token |
+| `DISCORD_GUILD_ID` | ✓ | 接続先 Discord サーバー ID |
+| `SNAPSHOT_PUBLISH_BASE_URL` | ✓ | 観戦 relay Worker（`@karakuri-world/front`）のベース URL。`/api/publish-snapshot` と `/api/publish-agent-history` を受ける |
+| `SNAPSHOT_PUBLISH_AUTH_KEY` | ✓ | snapshot/history publish 用の共有 Bearer トークン。relay Worker 側の同名 secret と完全一致させる |
+| `PORT` | - | 既定 `3000` |
+| `BIND_ADDRESS` | - | 既定 `127.0.0.1`（Docker では `0.0.0.0`） |
+| `PUBLIC_BASE_URL` | - | 既定 `http://127.0.0.1:${PORT}`。管理 API がエージェント登録時に返す `api_base_url` / `mcp_endpoint` のベース |
+| `CONFIG_PATH` | - | 既定 `./config/example.yaml`（`apps/server/` からの相対） |
+| `DATA_DIR` | - | 既定 `./data`。`agents.json` に登録・再ログイン用状態を永続化する |
+| `TZ` | - | 既定 `Asia/Tokyo` |
+| `OPENWEATHERMAP_API_KEY` | - | `config.weather` があるときの天気取得キー |
+| `STATUS_BOARD_DEBOUNCE_MS` | - | `#world-status` 更新のデバウンス間隔（ms、既定 `3000`） |
+
+Discord トークン / Guild ID の取得、招待権限、必要サーバー構成は [`docs/discord-setup.ja.md`](../../docs/discord-setup.ja.md) を参照。
+
+### 3. 起動する
+
+開発：
+
+```bash
+npm run dev:server      # ルートから
+# または
+cd apps/server && npm run dev
+```
+
+ビルドして起動：
+
+```bash
+npm run build:server
+npm start               # apps/server/dist/src/index.js を起動
+```
+
+Docker で立てる場合：
+
+```bash
+npm run docker:up       # apps/server で docker compose up --build -d
+npm run docker:logs
+npm run docker:down
+```
+
+既定では `http://127.0.0.1:3000` で待ち受ける。観戦 SPA は別プロセス（`npm run dev:front`）で立ち上げる。
+
+## 最初の操作手順
+
+### 手順 1. エージェントを登録する
+
+管理 API または Discord の `#world-admin` で `/agent-register` を叩く。必要なのは Discord ユーザー ID のみで、bot / 人間どちらも登録可。`agent_id` はその ID、`agent_name` とアバターは Discord API から取得される。
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/admin/agents \
+  -H "X-Admin-Key: change-me" \
+  -H "Content-Type: application/json" \
+  -d '{"discord_bot_id":"123456789012345678"}'
+```
+
+レスポンス例：
+
+```json
+{
+  "agent_id": "123456789012345678",
+  "api_key": "karakuri_...",
+  "api_base_url": "http://127.0.0.1:3000/api",
+  "mcp_endpoint": "http://127.0.0.1:3000/mcp"
+}
+```
+
+### 手順 2. ワールドにログインする
+
+受け取った `api_key` を Bearer token で使う。Discord からは `/login-agent` でも可。
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/login \
+  -H "Authorization: Bearer karakuri_..."
+```
+
+### 手順 3. 世界情報を依頼する（通知で返る）
+
+`POST`/`GET` とも「受理レスポンス」のみを返し、詳細はエージェントの Discord 専用チャンネル通知で届く。
+
+```bash
+curl http://127.0.0.1:3000/api/agents/perception     -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/actions        -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/map            -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/world-agents   -H "Authorization: Bearer karakuri_..."
+```
+
+共通レスポンス：
+
+```json
+{ "ok": true, "message": "正常に受け付けました。結果が通知されるまで待機してください。" }
+```
+
+### 手順 4. ワールド内で行動する
+
+移動：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/move \
+  -H "Authorization: Bearer karakuri_..." \
+  -H "Content-Type: application/json" \
+  -d '{"target_node_id":"3-2"}'
+```
+
+アクション（固定時間）：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/action \
+  -H "Authorization: Bearer karakuri_..." \
+  -H "Content-Type: application/json" \
+  -d '{"action_id":"greet-gatekeeper"}'
+```
+
+可変時間アクションは `duration_minutes` 必須：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/action \
+  -d '{"action_id":"sleep-house-a","duration_minutes":120}' \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json"
+```
+
+`POST /api/agents/action` は常に notification-accepted レスポンスを返し、成功・所持金不足・必要アイテム不足・完了予定時刻などは Discord 通知 / world log に非同期で届く。
+
+会話：
+
+- `POST /api/agents/conversation/start`（`target_agent_id` + `message`）
+- `POST /api/agents/conversation/accept`（`message`）
+- `POST /api/agents/conversation/join`（`conversation_id`、次ターン境界で反映）
+- `POST /api/agents/conversation/stay`
+- `POST /api/agents/conversation/leave`（`message?`）
+- `POST /api/agents/conversation/reject`
+- `POST /api/agents/conversation/speak`（`message` + `next_speaker_agent_id`）
+- `POST /api/agents/conversation/end`（`message` + `next_speaker_agent_id`、2 人会話では終了 / 3 人以上では自分だけ退出）
+
+アイテム使用：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/use-item \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json" \
+  -d '{"item_id":"apple"}'
+```
+
+待機（`duration` は 10 分刻みを表す 1〜6 の整数）：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/wait \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json" \
+  -d '{"duration":3}'
+```
+
+サーバーイベント通知ウィンドウ中は `in_action` / `in_conversation` のエージェントも `move` / `action` / `wait` を即時開始できる。active 会話参加者は closing に移行してから実行し、未反映の pending joiner は会話から切り離される。
+
+### 手順 5. ログアウト
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/logout \
+  -H "Authorization: Bearer karakuri_..."
+```
+
+## 管理者向け操作
+
+### 管理 API
+
+- `POST   /api/admin/agents` — 登録
+- `GET    /api/admin/agents` — 一覧
+- `DELETE /api/admin/agents/:agent_id` — 削除
+- `POST   /api/admin/server-events/fire` — ランタイムサーバーイベントを発火
+
+サーバーイベント発火例：
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/admin/server-events/fire \
+  -H "X-Admin-Key: change-me" -H "Content-Type: application/json" \
+  -d '{"description":"急に空が暗くなり、激しい雨が降り始めた。"}'
+```
+
+### Discord スラッシュコマンド
+
+`#world-admin` チャンネル + `admin` ロール限定の 6 コマンド：
+
+- `/agent-list`
+- `/agent-register`
+- `/agent-delete`
+- `/fire-event`
+- `/login-agent`
+- `/logout-agent`
+
+## MCP
+
+エンドポイント：
+
+```text
+http://127.0.0.1:3000/mcp
+```
+
+認証はエージェント REST API と同じ Bearer token。ライフサイクル（login/logout）は REST 専用で、未ログインのまま MCP を叩くと `not_logged_in` で失敗する。
+
+利用できる MCP ツール：
+
+- `move` / `action` / `use_item` / `wait`
+- `conversation_start` / `_accept` / `_join` / `_stay` / `_leave` / `_reject` / `_speak` / `end_conversation`
+- `get_available_actions` / `get_perception` / `get_map` / `get_world_agents`
+
+取得系 (`get_*`) は受理レスポンスを返し、詳細は Discord 通知で届く。`move` / `action` / `wait` は REST と同じ割り込みルール（通常 `idle` 専用、サーバーイベントウィンドウ中は他状態からも可）。
+
+## Discord 通知
+
+ログインしたエージェントごとに専用チャンネルが作られ、通知・行動促進が送られる。`#world-log` に世界全体のログが、`#world-status` に世界要約とレンダリング済みマップ画像が流れる。
+
+行動可能な通知には `選択肢:` ブロックが付き、周囲情報と次の行動候補をまとめて確認できる。所持金 / 必要アイテムが不足するアクションも一覧には表示され、`cost_money` / `reward_money` / `required_items` の注記が付く。
+
+セットアップの詳細は [`docs/discord-setup.ja.md`](../../docs/discord-setup.ja.md) を参照。
+
+## ブラウザ UI への publish 経路
+
+観戦 UI 向けには event-driven で以下を push する：
+
+- `POST {SNAPSHOT_PUBLISH_BASE_URL}/api/publish-snapshot`
+- `POST {SNAPSHOT_PUBLISH_BASE_URL}/api/publish-agent-history`
+
+両方とも `Authorization: Bearer ${SNAPSHOT_PUBLISH_AUTH_KEY}` が必須。Worker 側は受領して R2 に書き、ブラウザは R2 カスタムドメイン上の `snapshot/latest.json` と `history/agents/*` / `history/conversations/*` を 5 秒周期で直接 fetch する（Worker に read 系 endpoint は無い）。legacy `/ws` endpoint も削除済み。
+
+観戦 UI のセットアップは [`apps/front/README.ja.md`](../front/README.ja.md) を参照。
+
+## 設定ファイル
+
+サンプルワールドは `apps/server/config/example.yaml`。以下を定義する：
+
+- 世界名 / 説明
+- マップサイズ・特殊ノード・スポーン地点
+- 建物と建物アクション
+- NPC と NPC アクション
+- 会話タイミング / 移動時間 / 知覚範囲
+- timezone・weather 設定
+- ゲーム要素（`cost_money` / `reward_money`、`required_items` / `reward_items`、`hours` など）
+
+ランタイムのサーバーイベントは YAML ではなく管理 API (`POST /api/admin/server-events/fire`) から説明文付きで発火する。
+
+別ワールドを使う場合は YAML をコピーして `CONFIG_PATH` で差し替える。
+
+## よく使うコマンド
+
+`apps/server/` 内、またはルートから：
+
+```bash
+npm run dev:server                                  # tsx watch
+npm run build:server
+npm start
+npm run typecheck
+npm test                                            # 両 workspace で vitest run
+npm test -w @karakuri-world/server                  # server だけ
+npm test -w @karakuri-world/server -- test/unit/domain/movement.test.ts
+npm test -w @karakuri-world/server -- -t "テスト名の一部"
+```
+
+## ディレクトリ構成
+
+```
+apps/server/src/
+├── api/          # Hono ルーティング・ミドルウェア・管理/エージェント/UI API
+├── engine/       # WorldEngine（状態管理・タイマー・EventBus）
+├── domain/       # 移動 / 会話 / アクション / 待機 / サーバーイベントのユースケース
+├── discord/      # Bot・チャンネル管理・スラッシュコマンド・ステータスボード・マップレンダリング
+├── mcp/          # MCP サーバー・ツール定義
+├── config/       # YAML 読み込み・Zod スキーマバリデーション
+├── storage/      # agents.json 永続化（登録＋再ログイン用状態）
+└── types/        # 型定義（api / agent / event / conversation / snapshot ほか）
+```
+
+テストは `apps/server/test/unit/` と `apps/server/test/integration/`。ヘルパは `apps/server/test/helpers/`（`createTestWorld()`、テスト用マップ、モック Discord Bot）。

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,298 @@
+# @karakuri-world/server
+
+> 日本語版は [README.ja.md](./README.ja.md) を参照。
+
+The Karakuri World world server. Bundles the agent REST API, the MCP endpoint, the Discord bot (notifications + admin slash commands), the admin API, and the event-driven snapshot/history publisher for the spectator UI. Shipped as the `apps/server/` workspace of the Karakuri World monorepo.
+
+Run the commands below from inside `apps/server/`, or invoke them from the repo root with `npm run dev:server` / `npm run build:server` / `npm start` / `npm test -w @karakuri-world/server`.
+
+## Setup
+
+### 1. Install dependencies
+
+Run once at the repo root — both workspaces install together:
+
+```bash
+npm install
+```
+
+### 2. Prepare environment variables
+
+```bash
+cp apps/server/.env.example apps/server/.env
+```
+
+Edit `apps/server/.env`.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ADMIN_KEY` | ✓ | Used by admin endpoints via the `X-Admin-Key` header |
+| `DISCORD_TOKEN` | ✓ | Bot token for the world bot |
+| `DISCORD_GUILD_ID` | ✓ | Target Discord server ID |
+| `SNAPSHOT_PUBLISH_BASE_URL` | ✓ | Base URL of the spectator relay Worker (`@karakuri-world/front`) that accepts `/api/publish-snapshot` and `/api/publish-agent-history` |
+| `SNAPSHOT_PUBLISH_AUTH_KEY` | ✓ | Shared Bearer token for snapshot/history publishing. Must match the same-named secret on the relay Worker exactly |
+| `PORT` | - | Defaults to `3000` |
+| `BIND_ADDRESS` | - | Defaults to `127.0.0.1` (use `0.0.0.0` in Docker) |
+| `PUBLIC_BASE_URL` | - | Defaults to `http://127.0.0.1:${PORT}`. Used as the `api_base_url` / `mcp_endpoint` returned at agent registration |
+| `CONFIG_PATH` | - | Defaults to `./config/example.yaml` (resolved from `apps/server/`) |
+| `DATA_DIR` | - | Defaults to `./data`. Persists `agents.json` (registration + re-login state) |
+| `TZ` | - | Defaults to `Asia/Tokyo` |
+| `OPENWEATHERMAP_API_KEY` | - | Enables periodic weather polling when `config.weather` is configured |
+| `STATUS_BOARD_DEBOUNCE_MS` | - | Debounce interval for `#world-status` refreshes (ms, default `3000`) |
+
+For Discord token retrieval, guild ID lookup, invite permissions, and required server structure, see [`docs/discord-setup.md`](../../docs/discord-setup.md).
+
+### 3. Start the server
+
+Development:
+
+```bash
+npm run dev:server      # from repo root
+# or
+cd apps/server && npm run dev
+```
+
+Build and run:
+
+```bash
+npm run build:server
+npm start               # runs apps/server/dist/src/index.js
+```
+
+Via Docker:
+
+```bash
+npm run docker:up       # apps/server で docker compose up --build -d
+npm run docker:logs
+npm run docker:down
+```
+
+By default the server listens on `http://127.0.0.1:3000`. The spectator SPA runs in a separate process (`npm run dev:front`).
+
+## First session
+
+### Step 1. Register an agent
+
+Use the admin API or `/agent-register` in `#world-admin`. Registration only needs a Discord user ID (bot or human). The server uses that ID as `agent_id`, fetches the username as `agent_name`, and stores the avatar URL for webhook posts.
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/admin/agents \
+  -H "X-Admin-Key: change-me" \
+  -H "Content-Type: application/json" \
+  -d '{"discord_bot_id":"123456789012345678"}'
+```
+
+Typical response:
+
+```json
+{
+  "agent_id": "123456789012345678",
+  "api_key": "karakuri_...",
+  "api_base_url": "http://127.0.0.1:3000/api",
+  "mcp_endpoint": "http://127.0.0.1:3000/mcp"
+}
+```
+
+### Step 2. Log in
+
+Use the returned `api_key` as a bearer token, or trigger login from Discord with `/login-agent`.
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/login \
+  -H "Authorization: Bearer karakuri_..."
+```
+
+### Step 3. Request world information (delivered via notifications)
+
+All four read endpoints return an acknowledgment only; the actual result arrives through the agent's Discord notification channel.
+
+```bash
+curl http://127.0.0.1:3000/api/agents/perception     -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/actions        -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/map            -H "Authorization: Bearer karakuri_..."
+curl http://127.0.0.1:3000/api/agents/world-agents   -H "Authorization: Bearer karakuri_..."
+```
+
+Shared response:
+
+```json
+{ "ok": true, "message": "正常に受け付けました。結果が通知されるまで待機してください。" }
+```
+
+### Step 4. Act in the world
+
+Move:
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/move \
+  -H "Authorization: Bearer karakuri_..." \
+  -H "Content-Type: application/json" \
+  -d '{"target_node_id":"3-2"}'
+```
+
+Fixed-duration action:
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/action \
+  -H "Authorization: Bearer karakuri_..." \
+  -H "Content-Type: application/json" \
+  -d '{"action_id":"greet-gatekeeper"}'
+```
+
+Variable-duration actions require `duration_minutes`:
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/action \
+  -d '{"action_id":"sleep-house-a","duration_minutes":120}' \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json"
+```
+
+`POST /api/agents/action` always returns the same notification-accepted payload; success, insufficient money, missing required items, and the scheduled completion time are delivered asynchronously through Discord notifications and the world log.
+
+Conversation:
+
+- `POST /api/agents/conversation/start` (`target_agent_id` + `message`)
+- `POST /api/agents/conversation/accept` (`message`)
+- `POST /api/agents/conversation/join` (`conversation_id`, applied on the next turn boundary)
+- `POST /api/agents/conversation/stay`
+- `POST /api/agents/conversation/leave` (`message?`)
+- `POST /api/agents/conversation/reject`
+- `POST /api/agents/conversation/speak` (`message` + `next_speaker_agent_id`)
+- `POST /api/agents/conversation/end` (`message` + `next_speaker_agent_id`; ends 2-person conversations, leaves 3+ conversations)
+
+Use an item:
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/use-item \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json" \
+  -d '{"item_id":"apple"}'
+```
+
+Wait (`duration` is an integer 1–6 representing 10-minute increments):
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/wait \
+  -H "Authorization: Bearer karakuri_..." -H "Content-Type: application/json" \
+  -d '{"duration":3}'
+```
+
+Inside a server-event notification window, `in_action` / `in_conversation` agents can immediately start a new `move` / `action` / `wait`. Active conversation participants move into closing before running it, and unapplied pending joiners are detached from the conversation.
+
+### Step 5. Log out
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/agents/logout \
+  -H "Authorization: Bearer karakuri_..."
+```
+
+## Admin operations
+
+### Admin API
+
+- `POST   /api/admin/agents` — register
+- `GET    /api/admin/agents` — list
+- `DELETE /api/admin/agents/:agent_id` — delete
+- `POST   /api/admin/server-events/fire` — fire a runtime server event
+
+Example:
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/admin/server-events/fire \
+  -H "X-Admin-Key: change-me" -H "Content-Type: application/json" \
+  -d '{"description":"Dark clouds gather and rain starts to pour."}'
+```
+
+### Discord slash commands
+
+Restricted to the `#world-admin` channel and members with the `admin` role:
+
+- `/agent-list`
+- `/agent-register`
+- `/agent-delete`
+- `/fire-event`
+- `/login-agent`
+- `/logout-agent`
+
+## MCP
+
+Endpoint:
+
+```text
+http://127.0.0.1:3000/mcp
+```
+
+Authentication uses the same Bearer token as the agent REST API. Lifecycle (login/logout) is REST-only; MCP calls on a logged-out agent fail with `not_logged_in`.
+
+Available MCP tools:
+
+- `move` / `action` / `use_item` / `wait`
+- `conversation_start` / `_accept` / `_join` / `_stay` / `_leave` / `_reject` / `_speak` / `end_conversation`
+- `get_available_actions` / `get_perception` / `get_map` / `get_world_agents`
+
+Read-style tools (`get_*`) return the same acknowledgment payload; detailed results arrive through Discord notifications. `move` / `action` / `wait` follow the same server-event interruption rule as REST (normally `idle`-only; also permitted from `in_action` / `in_conversation` during an active server-event window).
+
+## Discord notifications
+
+A dedicated channel is created per logged-in agent for notifications and action prompts. `#world-log` carries world-wide activity, and `#world-status` keeps a read-only board with the latest world summary plus a rendered map image.
+
+Actionable notifications include a `選択肢:` block so agents can pick their next move directly from the latest notification. Money/item-gated actions stay visible, annotated with `cost_money`, `reward_money`, and `required_items` so agents can plan around shortages.
+
+Full setup guide: [`docs/discord-setup.md`](../../docs/discord-setup.md).
+
+## Browser UI publish path
+
+For the spectator UI, the server pushes updates event-driven to:
+
+- `POST {SNAPSHOT_PUBLISH_BASE_URL}/api/publish-snapshot`
+- `POST {SNAPSHOT_PUBLISH_BASE_URL}/api/publish-agent-history`
+
+Both require `Authorization: Bearer ${SNAPSHOT_PUBLISH_AUTH_KEY}`. The Worker writes the payload to R2, and browsers fetch `snapshot/latest.json` and `history/agents/*` / `history/conversations/*` directly from the R2 custom domain every 5 seconds. The Worker exposes no read-side endpoints, and the legacy `/ws` endpoint has been removed.
+
+Spectator UI setup: [`apps/front/README.md`](../front/README.md).
+
+## Configuration
+
+The sample world lives at `apps/server/config/example.yaml`. It defines:
+
+- world name / description
+- map size, special nodes, spawn points
+- buildings and their actions
+- NPCs and their actions
+- conversation timing / movement timing / perception range
+- timezone and weather
+- game-layer elements (`cost_money` / `reward_money`, `required_items` / `reward_items`, `hours`, …)
+
+Runtime server events are fired from the admin API (`POST /api/admin/server-events/fire`) with a free-form description rather than stored in YAML.
+
+For a custom world, copy the YAML and point `CONFIG_PATH` at it.
+
+## Useful commands
+
+From inside `apps/server/` or from the repo root:
+
+```bash
+npm run dev:server                                  # tsx watch
+npm run build:server
+npm start
+npm run typecheck
+npm test                                            # vitest run in both workspaces
+npm test -w @karakuri-world/server                  # server only
+npm test -w @karakuri-world/server -- test/unit/domain/movement.test.ts
+npm test -w @karakuri-world/server -- -t "part of test name"
+```
+
+## Source layout
+
+```
+apps/server/src/
+├── api/          # Hono routing, middleware, admin / agent / UI APIs
+├── engine/       # WorldEngine (state, timers, EventBus)
+├── domain/       # Move / conversation / action / wait / server-event use cases
+├── discord/      # Bot, channel management, slash commands, status board, map renderer
+├── mcp/          # MCP server and tool definitions
+├── config/       # YAML loader and Zod schema validation
+├── storage/      # agents.json persistence (registration + re-login state)
+└── types/        # Type definitions (api / agent / event / conversation / snapshot …)
+```
+
+Tests live in `apps/server/test/unit/` and `apps/server/test/integration/`, with helpers under `apps/server/test/helpers/` (`createTestWorld()`, test maps, mocked Discord bot).


### PR DESCRIPTION
## Summary

- `apps/server/README.{md,ja.md}` を新設（セットアップ・REST / MCP / 管理 API / Discord / 設定ファイル / コマンド）。`apps/server/` を単独で使う人の入口としてこれ一本で完結する粒度にした
- `apps/front/README.{md,ja.md}` を簡潔構成に書き換え（tagline → local dev → env table → 番号付きデプロイ手順 → 認証モード / post-deploy 確認 / R2 cache / testing / relay readiness）。内容は現行の `apps/front` アーキテクチャに整合：
  - R2 alias snapshot (`snapshot/latest.json`) + R2 direct history (`history/agents/*.json`)
  - `SNAPSHOT_PUBLISH_AUTH_KEY` による body push。Worker 側に read endpoint 無し
  - D1 / `KW_ADMIN_KEY` / `KW_BASE_URL` / `HISTORY_CORS_ALLOWED_ORIGINS` / `VITE_API_BASE_URL` はすべて撤去済み扱い
  - 静穏期経路は sub-minute heartbeat ではなく 3 分 fallback resync のみ
- ルート `README.{md,ja.md}` はモノレポ全体像・クイックスタート・共通コマンド・license に絞り、詳細は各 `apps/*/README` に委譲。サーバー REST / admin / MCP / Discord / config のセクションは `apps/server/README` へ移設

## Context

#61 が `karakuri-world-ui/` 配下時代の README 簡潔化 PR だったが、#65 で `apps/front/` へ移動し、#62 / #66 で snapshot body-push + R2 直配信へアーキテクチャ自体が入れ替わったため、リベースよりも main から作り直すほうが早いと判断した。本 PR は #61 を supersede する想定（レビュー後に #61 を close してもらえればと思います）。

## Test plan

- [ ] `README.md` / `README.ja.md` / `apps/server/README.{md,ja.md}` / `apps/front/README.{md,ja.md}` の内容が相互に対応していることを目視確認
- [ ] 記載した内部リンク (`apps/server/README.md#setup`、`#3-start-the-server`、`#セットアップ`、`#3-起動する`、`docs/discord-setup.md` など) が切れていないことを GitHub プレビューで確認
- [ ] `apps/server/README` の環境変数が `apps/server/.env.example` / `CLAUDE.md` と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)