### PR TITLE
fix(front): モバイルの BottomSheet エージェント一覧をスクロール可能にする

### DIFF
--- a/apps/front/app/components/layout/BottomSheet.tsx
+++ b/apps/front/app/components/layout/BottomSheet.tsx
@@ -75,7 +75,7 @@ export function BottomSheet({
               )}
             </section>
 
-            <section className="min-h-0 flex-1 space-y-2 overflow-hidden">
+            <section className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
               <div className="flex items-center justify-between gap-3">
                 <h2 className="text-sm font-medium text-slate-200">エージェント一覧</h2>
                 <span className="text-xs text-slate-400">{agents.length} 人</span>


### PR DESCRIPTION
## Summary
- モバイル縦画面（および PC 縦画面）で表示される BottomSheet のエージェント一覧が、要素数が多くなってもスクロールできず見切れていた問題を修正
- 原因は、エージェント一覧を囲む `<section>` が `display: flex` になっておらず、子要素 `mobile-agent-list` の `flex-1 / min-h-0` が効かずに `overflow-y-auto` が起動していなかったこと
- `<section>` を `flex flex-col` に変更し、flex 配下で副作用が出る `space-y-2` は `gap-2` に置換

## Test plan
- [ ] モバイル縦画面でエージェント一覧に多数のエージェントを表示し、一覧エリアだけが独立して縦スクロールすることを確認
- [ ] サーバーイベントカードが上部で固定表示されていること
- [ ] list → detail の切り替え、タップによる選択が引き続き動作すること
- [ ] PC 縦画面（`lg` 以下 portrait）でも同様に動作すること
- [ ] `npm run typecheck` / `npm test -w @karakuri-world/front`

🤖 Generated with [Claude Code](https://claude.com/claude-code)