### PR TITLE
fix(conversation): emitEvent 後段の副作用例外で会話 timer が失われる問題を修正

### DIFF
--- a/apps/server/src/domain/actions.ts
+++ b/apps/server/src/domain/actions.ts
@@ -30,6 +30,13 @@ export type ActionSource =
       action: ActionConfig;
     };
 
+function summarizeAgentItems(items: ReadonlyArray<AgentItem> | undefined): string {
+  if (!items || items.length === 0) {
+    return 'none';
+  }
+  return items.map((item) => `${item.item_id}x${item.quantity}`).join(',');
+}
+
 function requireActionReadyAgent(engine: WorldEngine, agentId: string): LoggedInAgent {
   const agent = engine.state.getLoggedIn(agentId);
   if (!agent) {
@@ -382,7 +389,14 @@ export function handleActionCompleted(engine: WorldEngine, timer: ActionTimer): 
     engine.state.setItems(timer.agent_id, granted.items);
   }
   if (rewardMoney > 0 || (source.action.reward_items?.length ?? 0) > 0) {
-    engine.persistLoggedInAgentState(timer.agent_id);
+    try {
+      engine.persistLoggedInAgentState(timer.agent_id);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const summary = `エージェント状態の保存に失敗しました（agent_id=${timer.agent_id}, action_id=${timer.action_id}, reward_money=${rewardMoney}, items_granted=${summarizeAgentItems(granted.granted)}, items_dropped=${summarizeAgentItems(granted.dropped)}）`;
+      console.warn(`${summary}: ${errorMessage}`);
+      engine.reportError(`${summary}。idle に復帰しました。原因: ${errorMessage}`);
+    }
   }
 
   const updatedAgent = engine.state.getLoggedIn(timer.agent_id);

--- a/apps/server/src/domain/conversation.ts
+++ b/apps/server/src/domain/conversation.ts
@@ -877,11 +877,10 @@ export function speak(engine: WorldEngine, agentId: string, request: Conversatio
   const conversation = requireActiveConversation(engine, agentId, ['active', 'closing']);
   const turnTimer = ensureTurn(engine, conversation, agentId);
   const message = ensureMessage(request.message);
-  engine.timerManager.cancel(turnTimer.timer_id);
-
   const nextSpeakerAgentId = conversation.status === 'closing'
     ? resolveClosingNextSpeaker(conversation, agentId, request.next_speaker_agent_id)
     : resolveNextSpeaker(conversation, agentId, request.next_speaker_agent_id);
+  engine.timerManager.cancel(turnTimer.timer_id);
   const listeners = getOtherParticipants(conversation, agentId);
   const turn = conversation.current_turn + 1;
   conversation.current_turn = turn;
@@ -918,9 +917,9 @@ export function endConversationByAgent(engine: WorldEngine, agentId: string, req
   const conversation = requireActiveConversation(engine, agentId, ['active']);
   const turnTimer = ensureTurn(engine, conversation, agentId);
   const message = ensureMessage(request.message);
-  engine.timerManager.cancel(turnTimer.timer_id);
 
   if (conversation.participant_agent_ids.length <= 2) {
+    engine.timerManager.cancel(turnTimer.timer_id);
     const otherAgentId = getOtherParticipants(conversation, agentId)[0]!;
     const turn = conversation.current_turn + 1;
     conversation.current_turn = turn;
@@ -960,6 +959,7 @@ export function endConversationByAgent(engine: WorldEngine, agentId: string, req
     remainingParticipantIds,
     request.next_speaker_agent_id,
   );
+  engine.timerManager.cancel(turnTimer.timer_id);
   const turn = conversation.current_turn + 1;
   conversation.current_turn = turn;
 

--- a/apps/server/src/domain/use-item.ts
+++ b/apps/server/src/domain/use-item.ts
@@ -20,6 +20,10 @@ export interface ValidatedUseItem {
   item_type: ItemType;
 }
 
+function summarizeConsumedItem(itemId: string): string {
+  return `${itemId}x1`;
+}
+
 function resolveVenueHints(engine: WorldEngine, itemId: string): string[] {
   const hints: string[] = [];
   for (const building of engine.config.map.buildings) {
@@ -143,7 +147,14 @@ export function handleItemUseCompleted(engine: WorldEngine, timer: ItemUseTimer)
     timer.agent_id,
     consumeItems(agent.items, [{ item_id: timer.item_id, quantity: 1 }]),
   );
-  engine.persistLoggedInAgentState(timer.agent_id);
+  try {
+    engine.persistLoggedInAgentState(timer.agent_id);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const summary = `エージェント状態の保存に失敗しました（agent_id=${timer.agent_id}, item_id=${timer.item_id}, items_consumed=${summarizeConsumedItem(timer.item_id)}）`;
+    console.warn(`${summary}: ${errorMessage}`);
+    engine.reportError(`${summary}。idle に復帰しました。原因: ${errorMessage}`);
+  }
 
   engine.state.setState(timer.agent_id, 'idle');
   startIdleReminder(engine, timer.agent_id);

--- a/apps/server/src/engine/world-engine.ts
+++ b/apps/server/src/engine/world-engine.ts
@@ -711,6 +711,16 @@ export class WorldEngine {
     this.onRegistrationChanged?.(agents);
   }
 
+  private handleEventSideEffectError(sideEffect: string, eventType: WorldEvent['type'], error: unknown): void {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`World event ${sideEffect} threw.`, error);
+    try {
+      this.onError?.(`ワールドイベントの副作用に失敗しました (${sideEffect}, event: ${eventType}): ${errorMessage}`);
+    } catch (reportError) {
+      console.error('World error reporter threw.', reportError);
+    }
+  }
+
   emitEvent(event: EmittableWorldEvent): void {
     const fullEvent = {
       ...event,
@@ -724,10 +734,18 @@ export class WorldEngine {
       console.error('World event handler threw.', error);
     }
 
-    this.agentHistoryManager?.recordEvent(fullEvent);
+    try {
+      this.agentHistoryManager?.recordEvent(fullEvent);
+    } catch (error) {
+      this.handleEventSideEffectError('history recording', fullEvent.type, error);
+    }
 
     if (isSnapshotTriggerEvent(fullEvent.type)) {
-      this.snapshotPublisher?.requestPublish();
+      try {
+        this.snapshotPublisher?.requestPublish();
+      } catch (error) {
+        this.handleEventSideEffectError('snapshot publishing', fullEvent.type, error);
+      }
     }
   }
 

--- a/apps/server/test/unit/domain/actions.test.ts
+++ b/apps/server/test/unit/domain/actions.test.ts
@@ -4,6 +4,7 @@ import type { WorldEngine } from '../../../src/engine/world-engine.js';
 import { formatActionSourceLine, getAvailableActionSources } from '../../../src/domain/actions.js';
 import { WorldError } from '../../../src/types/api.js';
 import type { NodeId } from '../../../src/types/data-model.js';
+import type { WorldEvent } from '../../../src/types/event.js';
 import type { ActionTimer } from '../../../src/types/timer.js';
 import { createTestMapConfig } from '../../helpers/test-map.js';
 import { createTestWorld } from '../../helpers/test-world.js';
@@ -429,6 +430,7 @@ describe('actions domain', () => {
     const { engine } = createTestWorld({
       config: {
         economy: { initial_money: 1000 },
+        idle_reminder: { interval_ms: 60_000 },
         map: {
           ...createTestWorld().config.map,
           buildings: [
@@ -509,6 +511,66 @@ describe('actions domain', () => {
       { item_id: 'chair', quantity: 1 },
       { item_id: 'wood', quantity: 1 },
     ]);
+  });
+
+  it('recovers to idle when action completion persistence fails', async () => {
+    let failPersist = false;
+    const onRegistrationChanged = vi.fn(() => {
+      if (failPersist) {
+        throw new Error('persist failed');
+      }
+    });
+    const { engine } = createTestWorld({
+      config: {
+        economy: { initial_money: 1000 },
+        idle_reminder: { interval_ms: 60_000 },
+        map: {
+          ...createTestWorld().config.map,
+          buildings: [
+            {
+              building_id: 'building-workshop',
+              name: 'Workshop',
+              description: 'A workshop.',
+              wall_nodes: ['1-3', '1-4', '1-5', '2-3', '2-5'],
+              interior_nodes: ['2-4'],
+              door_nodes: ['3-4'],
+              actions: [
+                {
+                  action_id: 'work',
+                  name: 'Work',
+                  description: 'Do work.',
+                  duration_ms: 1000,
+                  reward_money: 500,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      engineOptions: { onRegistrationChanged },
+    });
+    const alice = await createLoggedInAgent(engine);
+    engine.state.setNode(alice.agent_id, '2-4');
+    const reportErrorSpy = vi.spyOn(engine, 'reportError');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events: WorldEvent[] = [];
+    engine.eventBus.onAny((event) => events.push(event));
+
+    engine.executeAction(alice.agent_id, { action_id: 'work' });
+    failPersist = true;
+
+    vi.advanceTimersByTime(1000);
+
+    expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('idle');
+    expect(engine.timerManager.find((timer) => timer.type === 'idle_reminder' && timer.agent_id === alice.agent_id)).toBeDefined();
+    expect(engine.timerManager.find((timer) => timer.type === 'action' && timer.agent_id === alice.agent_id)).toBeUndefined();
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'action_completed',
+      agent_id: alice.agent_id,
+      action_id: 'work',
+    }));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining(`agent_id=${alice.agent_id}`));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('action_id=work'));
   });
 
   it('shows actions with required_items even when the agent does not hold them', async () => {

--- a/apps/server/test/unit/domain/conversation.test.ts
+++ b/apps/server/test/unit/domain/conversation.test.ts
@@ -4,11 +4,15 @@ import {
   beginClosingConversation,
   detachParticipantFromClosingConversation,
 } from '../../../src/domain/conversation.js';
-import type { WorldEngine } from '../../../src/engine/world-engine.js';
+import type { WorldEngine, WorldEngineOptions } from '../../../src/engine/world-engine.js';
 import type { WorldEvent } from '../../../src/types/event.js';
 import { createTestWorld } from '../../helpers/test-world.js';
 
-async function setupConversationWorld(options?: { max_turns?: number; inactive_check_turns?: number }) {
+async function setupConversationWorld(options?: {
+  max_turns?: number;
+  inactive_check_turns?: number;
+  engineOptions?: WorldEngineOptions;
+}) {
   const { engine } = createTestWorld({
     config: {
       conversation: {
@@ -19,6 +23,7 @@ async function setupConversationWorld(options?: { max_turns?: number; inactive_c
         turn_timeout_ms: 1000,
       },
     },
+    engineOptions: options?.engineOptions,
   });
   const alice = await engine.registerAgent({ discord_bot_id: 'bot-alice', });
   const bob = await engine.registerAgent({ discord_bot_id: 'bot-bob', });
@@ -65,6 +70,36 @@ function findConversationIntervalTimer(engine: WorldEngine, conversationId: stri
   return engine.timerManager.find(
     (timer) => timer.type === 'conversation_interval' && 'conversation_id' in timer && timer.conversation_id === conversationId,
   );
+}
+
+function createFaultyEmitSideEffectOptions(mode: 'history' | 'snapshot') {
+  if (mode === 'history') {
+    return {
+      agentHistoryManager: {
+        recordEvent: vi.fn((event: WorldEvent) => {
+          if (event.type === 'conversation_message') {
+            throw new Error('history boom');
+          }
+        }),
+        dispose: vi.fn(async () => {}),
+      } as unknown as WorldEngineOptions['agentHistoryManager'],
+    } satisfies WorldEngineOptions;
+  }
+
+  return {
+    snapshotPublisher: {
+      requestPublish: vi.fn(() => {
+        throw new Error('snapshot boom');
+      }),
+      getStats: vi.fn(() => ({
+        pending: false,
+        consecutiveFailures: 0,
+        gaveUp: false,
+        state: 'idle' as const,
+      })),
+      dispose: vi.fn(async () => {}),
+    } as unknown as WorldEngineOptions['snapshotPublisher'],
+  } satisfies WorldEngineOptions;
 }
 
 describe('conversation domain', () => {
@@ -321,6 +356,27 @@ describe('conversation domain', () => {
     expect(() => engine.acceptConversation(bob.agent_id, { message: '   ' })).toThrow(
       expect.objectContaining({ code: 'invalid_request' }),
     );
+  });
+
+  it.each(['history', 'snapshot'] as const)('continues acceptConversation when %s side effects throw', async (mode) => {
+    const { engine, alice, bob } = await setupConversationWorld({
+      max_turns: 10,
+      engineOptions: createFaultyEmitSideEffectOptions(mode),
+    });
+    const started = engine.startConversation(alice.agent_id, {
+      target_agent_id: bob.agent_id,
+      message: 'Hello',
+    });
+
+    expect(engine.acceptConversation(bob.agent_id, { message: 'Hi' })).toEqual({ status: 'ok' });
+
+    expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('in_conversation');
+    expect(engine.state.getLoggedIn(bob.agent_id)?.state).toBe('in_conversation');
+    expect(engine.state.conversations.get(started.conversation_id)).toEqual(expect.objectContaining({
+      status: 'active',
+      current_turn: 2,
+    }));
+    expect(findConversationIntervalTimer(engine, started.conversation_id)).toBeDefined();
   });
 
   it('rejects speak when turn timer is missing', async () => {
@@ -1199,6 +1255,31 @@ describe('conversation domain', () => {
       next_speaker_agent_id: bob.agent_id,
     })).toEqual({ turn: beforeTurn + 1 });
     unsubscribe();
+  });
+
+  it.each(['history', 'snapshot'] as const)('continues speak when %s side effects throw', async (mode) => {
+    const { engine, alice, bob } = await setupConversationWorld({
+      max_turns: 10,
+      engineOptions: createFaultyEmitSideEffectOptions(mode),
+    });
+    const started = engine.startConversation(alice.agent_id, {
+      target_agent_id: bob.agent_id,
+      message: 'Hello Bob',
+    });
+    engine.acceptConversation(bob.agent_id, { message: 'Hello Alice' });
+    vi.advanceTimersByTime(500);
+
+    expect(engine.speak(alice.agent_id, {
+      message: 'Passing to Bob.',
+      next_speaker_agent_id: bob.agent_id,
+    })).toEqual({ turn: 3 });
+
+    expect(engine.state.conversations.get(started.conversation_id)).toEqual(expect.objectContaining({
+      status: 'active',
+      current_turn: 3,
+    }));
+    expect(findConversationIntervalTimer(engine, started.conversation_id)).toBeDefined();
+    expect(findConversationTurnTimer(engine, started.conversation_id)).toBeUndefined();
   });
 
   it('keeps the turn timer when closing speak validation fails in a 3-person conversation', async () => {

--- a/apps/server/test/unit/domain/conversation.test.ts
+++ b/apps/server/test/unit/domain/conversation.test.ts
@@ -4,6 +4,7 @@ import {
   beginClosingConversation,
   detachParticipantFromClosingConversation,
 } from '../../../src/domain/conversation.js';
+import type { WorldEngine } from '../../../src/engine/world-engine.js';
 import type { WorldEvent } from '../../../src/types/event.js';
 import { createTestWorld } from '../../helpers/test-world.js';
 
@@ -33,6 +34,37 @@ async function setupGroupConversationWorld(options?: { max_turns?: number; inact
   await engine.loginAgent(carol.agent_id);
   engine.state.setNode(carol.agent_id, '3-2');
   return { engine, alice, bob, carol };
+}
+
+async function setupThreeParticipantConversationTurn(options?: { max_turns?: number; inactive_check_turns?: number }) {
+  const { engine, alice, bob, carol } = await setupGroupConversationWorld(options);
+  const started = engine.startConversation(alice.agent_id, {
+    target_agent_id: bob.agent_id,
+    message: 'Hello Bob',
+  });
+  engine.acceptConversation(bob.agent_id, { message: 'Hello Alice' });
+  vi.advanceTimersByTime(500);
+  engine.joinConversation(carol.agent_id, {
+    conversation_id: started.conversation_id,
+  });
+  engine.speak(alice.agent_id, {
+    message: 'Carolも来たよ。',
+    next_speaker_agent_id: bob.agent_id,
+  });
+  vi.advanceTimersByTime(500);
+  return { engine, alice, bob, carol, started };
+}
+
+function findConversationTurnTimer(engine: WorldEngine, conversationId: string) {
+  return engine.timerManager.find(
+    (timer) => timer.type === 'conversation_turn' && 'conversation_id' in timer && timer.conversation_id === conversationId,
+  );
+}
+
+function findConversationIntervalTimer(engine: WorldEngine, conversationId: string) {
+  return engine.timerManager.find(
+    (timer) => timer.type === 'conversation_interval' && 'conversation_id' in timer && timer.conversation_id === conversationId,
+  );
 }
 
 describe('conversation domain', () => {
@@ -1121,6 +1153,89 @@ describe('conversation domain', () => {
     })).toThrow(expect.objectContaining({ code: 'invalid_next_speaker' }));
   });
 
+  it.each([
+    ['next_speaker_required', ''],
+    ['cannot_nominate_self', 'self'],
+    ['invalid_next_speaker', 'outsider'],
+  ] as const)('keeps the turn timer when speak validation fails (%s)', async (code, mode) => {
+    const { engine, alice, bob } = await setupConversationWorld({ max_turns: 10 });
+    const started = engine.startConversation(alice.agent_id, {
+      target_agent_id: bob.agent_id,
+      message: 'Hello Bob',
+    });
+    engine.acceptConversation(bob.agent_id, { message: 'Hello Alice' });
+    vi.advanceTimersByTime(500);
+
+    const events: WorldEvent[] = [];
+    const unsubscribe = engine.eventBus.onAny((event) => {
+      if (event.type === 'conversation_message') {
+        events.push(event);
+      }
+    });
+    const conversationBefore = engine.state.conversations.get(started.conversation_id);
+    expect(conversationBefore).not.toBeNull();
+    const beforeSpeakerAgentId = conversationBefore?.current_speaker_agent_id;
+    const beforeTurn = conversationBefore?.current_turn ?? 0;
+
+    const nextSpeakerAgentId = mode === 'self'
+      ? alice.agent_id
+      : mode === 'outsider'
+        ? 'nonexistent-agent'
+        : '';
+    expect(() => engine.speak(alice.agent_id, {
+      message: 'Still my turn.',
+      next_speaker_agent_id: nextSpeakerAgentId,
+    })).toThrow(expect.objectContaining({ code }));
+
+    const conversationAfterError = engine.state.conversations.get(started.conversation_id);
+    expect(findConversationTurnTimer(engine, started.conversation_id)).toBeDefined();
+    expect(findConversationIntervalTimer(engine, started.conversation_id)).toBeUndefined();
+    expect(conversationAfterError?.current_speaker_agent_id).toBe(beforeSpeakerAgentId);
+    expect(conversationAfterError?.current_turn).toBe(beforeTurn);
+    expect(events).toEqual([]);
+
+    expect(engine.speak(alice.agent_id, {
+      message: 'Now over to Bob.',
+      next_speaker_agent_id: bob.agent_id,
+    })).toEqual({ turn: beforeTurn + 1 });
+    unsubscribe();
+  });
+
+  it('keeps the turn timer when closing speak validation fails in a 3-person conversation', async () => {
+    const { engine, alice, bob, started } = await setupThreeParticipantConversationTurn({ max_turns: 10 });
+    beginClosingConversation(engine, started.conversation_id, bob.agent_id, 'server_event');
+
+    const events: WorldEvent[] = [];
+    const unsubscribe = engine.eventBus.onAny((event) => {
+      if (event.type === 'conversation_message') {
+        events.push(event);
+      }
+    });
+    const conversationBefore = engine.state.conversations.get(started.conversation_id);
+    expect(conversationBefore?.status).toBe('closing');
+    expect(conversationBefore?.participant_agent_ids).toHaveLength(3);
+    const beforeSpeakerAgentId = conversationBefore?.current_speaker_agent_id;
+    const beforeTurn = conversationBefore?.current_turn ?? 0;
+
+    expect(() => engine.speak(bob.agent_id, {
+      message: 'I will talk again.',
+      next_speaker_agent_id: 'nonexistent-agent',
+    })).toThrow(expect.objectContaining({ code: 'invalid_next_speaker' }));
+
+    const conversationAfterError = engine.state.conversations.get(started.conversation_id);
+    expect(findConversationTurnTimer(engine, started.conversation_id)).toBeDefined();
+    expect(findConversationIntervalTimer(engine, started.conversation_id)).toBeUndefined();
+    expect(conversationAfterError?.current_speaker_agent_id).toBe(beforeSpeakerAgentId);
+    expect(conversationAfterError?.current_turn).toBe(beforeTurn);
+    expect(events).toEqual([]);
+
+    expect(engine.speak(bob.agent_id, {
+      message: 'Aliceへ渡します。',
+      next_speaker_agent_id: alice.agent_id,
+    })).toEqual({ turn: beforeTurn + 1 });
+    unsubscribe();
+  });
+
   it('removes the agent and continues the conversation when ending a 3+ participant conversation', async () => {
     const { engine, alice, bob, carol } = await setupGroupConversationWorld({ max_turns: 10 });
     const leaveEvents: WorldEvent[] = [];
@@ -1175,6 +1290,42 @@ describe('conversation domain', () => {
     );
     expect(intervalTimers).toHaveLength(1);
 
+    unsubscribe();
+  });
+
+  it.each([
+    ['invalid_next_speaker', 'nonexistent-agent'],
+    ['cannot_nominate_self', 'self'],
+  ] as const)('keeps the turn timer when group endConversation validation fails (%s)', async (code, nextSpeaker) => {
+    const { engine, bob, carol, started } = await setupThreeParticipantConversationTurn({ max_turns: 10 });
+    const events: WorldEvent[] = [];
+    const unsubscribe = engine.eventBus.onAny((event) => {
+      if (event.type === 'conversation_message' || event.type === 'conversation_leave') {
+        events.push(event);
+      }
+    });
+    const conversationBefore = engine.state.conversations.get(started.conversation_id);
+    expect(conversationBefore?.status).toBe('active');
+    const beforeStatus = conversationBefore?.status;
+    const beforeClosingReason = conversationBefore?.closing_reason;
+    const beforeTurn = conversationBefore?.current_turn ?? 0;
+
+    expect(() => engine.endConversation(bob.agent_id, {
+      message: 'I need to leave.',
+      next_speaker_agent_id: nextSpeaker === 'self' ? bob.agent_id : nextSpeaker,
+    })).toThrow(expect.objectContaining({ code }));
+
+    const conversationAfterError = engine.state.conversations.get(started.conversation_id);
+    expect(findConversationTurnTimer(engine, started.conversation_id)).toBeDefined();
+    expect(findConversationIntervalTimer(engine, started.conversation_id)).toBeUndefined();
+    expect(conversationAfterError?.status).toBe(beforeStatus);
+    expect(conversationAfterError?.closing_reason).toBe(beforeClosingReason);
+    expect(events).toEqual([]);
+
+    expect(engine.endConversation(bob.agent_id, {
+      message: 'I need to leave.',
+      next_speaker_agent_id: carol.agent_id,
+    })).toEqual({ turn: beforeTurn + 1 });
     unsubscribe();
   });
 

--- a/apps/server/test/unit/domain/use-item.test.ts
+++ b/apps/server/test/unit/domain/use-item.test.ts
@@ -73,6 +73,7 @@ describe('use-item domain', () => {
   it('consumes general/food/drink items and emits completed with item_type', async () => {
     const { engine } = createTestWorld({
       config: {
+        idle_reminder: { interval_ms: 60_000 },
         items: [
           { item_id: 'bread', name: 'パン', description: '焼きたて', type: 'food' as const, stackable: true, max_stack: 5 },
         ],
@@ -98,6 +99,47 @@ describe('use-item domain', () => {
     // Item consumed
     expect(engine.state.getLoggedIn(alice.agent_id)?.items).toEqual([{ item_id: 'bread', quantity: 1 }]);
     expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('idle');
+  });
+
+  it('recovers to idle when item-use completion persistence fails', async () => {
+    let failPersist = false;
+    const onRegistrationChanged = vi.fn(() => {
+      if (failPersist) {
+        throw new Error('persist failed');
+      }
+    });
+    const { engine } = createTestWorld({
+      config: {
+        idle_reminder: { interval_ms: 60_000 },
+        items: [
+          { item_id: 'bread', name: 'パン', description: '焼きたて', type: 'food' as const, stackable: true, max_stack: 5 },
+        ],
+      },
+      engineOptions: { onRegistrationChanged },
+    });
+    const alice = await createLoggedInAgent(engine);
+    engine.state.setItems(alice.agent_id, [{ item_id: 'bread', quantity: 2 }]);
+    const reportErrorSpy = vi.spyOn(engine, 'reportError');
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events: WorldEvent[] = [];
+    engine.eventBus.onAny((event) => events.push(event));
+
+    engine.useItem(alice.agent_id, { item_id: 'bread' });
+    failPersist = true;
+
+    vi.advanceTimersByTime(600000);
+
+    expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('idle');
+    expect(engine.state.getLoggedIn(alice.agent_id)?.items).toEqual([{ item_id: 'bread', quantity: 1 }]);
+    expect(engine.timerManager.find((timer) => timer.type === 'idle_reminder' && timer.agent_id === alice.agent_id)).toBeDefined();
+    expect(engine.timerManager.find((timer) => timer.type === 'item_use' && timer.agent_id === alice.agent_id)).toBeUndefined();
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'item_use_completed',
+      agent_id: alice.agent_id,
+      item_id: 'bread',
+    }));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining(`agent_id=${alice.agent_id}`));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('item_id=bread'));
   });
 
   it('resolves venue hints from multiple buildings and NPCs', async () => {


### PR DESCRIPTION
## Summary

- #53 のレビュー追跡コメント (https://github.com/KarakuriAgent/karakuri-world/issues/53#issuecomment-4310480463) で指摘された境界リスクへの対応。
- `WorldEngine.emitEvent()` の `try/catch` は `eventBus.emit` のみを包んでおり、後段の `agentHistoryManager.recordEvent` / `snapshotPublisher.requestPublish` は未保護だった。これらが同期 throw した場合、`acceptConversation()` / `speak()` の `emitEvent()` 直後で処理が中断し、両者 `in_conversation` / `conversation.status='active'` / timer 0 件のデッドロックに陥り得た。
- 両副作用を個別 `try/catch` で包み、`onError`（Discord エラーレポート）経由で運用通知する。`onError` 自体が throw した場合は console.error にフォールバックし、エンジン側を巻き込まない。

## 変更点

- `apps/server/src/engine/world-engine.ts`
  - `emitEvent()` 内の `recordEvent` / `requestPublish` を個別 `try/catch` で保護。
  - `handleEventSideEffectError()` ヘルパーを追加し、`console.error` ＋ `onError` 通知を集約。
- `apps/server/test/unit/domain/conversation.test.ts`
  - `acceptConversation()` / `speak()` で history / snapshot 副作用が throw しても会話進行 timer が作られ、状態が壊れないことを `it.each` で検証。

## Test plan

- [x] `npm test -w @karakuri-world/server -- test/unit/domain/conversation.test.ts` (47 / 47 pass)
- [x] `npm run typecheck` (server / front 両方 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)