### PR TITLE
fix(action): action 開始時 persist 失敗で state/timer/action_started が失われる問題を修正

### DIFF
--- a/apps/server/src/domain/actions.ts
+++ b/apps/server/src/domain/actions.ts
@@ -309,7 +309,14 @@ export function executeValidatedAction(
     engine.state.setItems(agent.agent_id, consumeItems(agent.items, source.action.required_items));
   }
   if (costMoney > 0 || itemsConsumed.length > 0) {
-    engine.persistLoggedInAgentState(agent.agent_id);
+    try {
+      engine.persistLoggedInAgentState(agent.agent_id);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      const summary = `エージェント状態の保存に失敗しました（agent_id=${agent.agent_id}, action_id=${source.action.action_id}, cost_money=${costMoney}, items_consumed=${summarizeAgentItems(itemsConsumed)}）`;
+      console.warn(`${summary}: ${errorMessage}`);
+      engine.reportError(`${summary}。アクションは続行します。原因: ${errorMessage}`);
+    }
   }
 
   cancelIdleReminder(engine, agent.agent_id);

--- a/apps/server/src/engine/world-engine.ts
+++ b/apps/server/src/engine/world-engine.ts
@@ -493,7 +493,11 @@ export class WorldEngine {
   }
 
   reportError(message: string): void {
-    this.onError?.(message);
+    try {
+      this.onError?.(message);
+    } catch (error) {
+      console.error('World error reporter threw.', error);
+    }
   }
 
   getWeatherState(): WeatherState | null {

--- a/apps/server/test/unit/domain/actions.test.ts
+++ b/apps/server/test/unit/domain/actions.test.ts
@@ -573,6 +573,151 @@ describe('actions domain', () => {
     expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('action_id=work'));
   });
 
+  it('continues action start when action persistence fails', async () => {
+    let failPersist = false;
+    const onRegistrationChanged = vi.fn(() => {
+      if (failPersist) {
+        throw new Error('persist failed');
+      }
+    });
+    const { engine } = createTestWorld({
+      config: {
+        economy: { initial_money: 1000 },
+        map: {
+          ...createTestWorld().config.map,
+          buildings: [
+            {
+              building_id: 'building-workshop',
+              name: 'Workshop',
+              description: 'A workshop.',
+              wall_nodes: ['1-3', '1-4', '1-5', '2-3', '2-5'],
+              interior_nodes: ['2-4'],
+              door_nodes: ['3-4'],
+              actions: [
+                {
+                  action_id: 'craft-chair',
+                  name: 'Craft chair',
+                  description: 'Build a chair.',
+                  duration_ms: 1000,
+                  cost_money: 100,
+                  required_items: [{ item_id: 'wood', quantity: 2 }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      engineOptions: { onRegistrationChanged },
+    });
+    const alice = await createLoggedInAgent(engine);
+    engine.state.setNode(alice.agent_id, '2-4');
+    engine.state.setItems(alice.agent_id, [{ item_id: 'wood', quantity: 3 }]);
+    const reportErrorSpy = vi.spyOn(engine, 'reportError');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events: WorldEvent[] = [];
+    engine.eventBus.onAny((event) => events.push(event));
+
+    failPersist = true;
+    const response = engine.executeAction(alice.agent_id, { action_id: 'craft-chair' });
+
+    expect(response.ok).toBe(true);
+    expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('in_action');
+    expect(engine.state.getLoggedIn(alice.agent_id)?.money).toBe(900);
+    expect(engine.state.getLoggedIn(alice.agent_id)?.items).toEqual([{ item_id: 'wood', quantity: 1 }]);
+    expect(engine.state.getById(alice.agent_id)?.money).toBe(1000);
+    expect(engine.state.getById(alice.agent_id)?.items ?? []).toEqual([]);
+    expect(engine.timerManager.find((timer) => timer.type === 'action' && timer.agent_id === alice.agent_id)).toBeDefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'action_started',
+        agent_id: alice.agent_id,
+        action_id: 'craft-chair',
+        cost_money: 100,
+        items_consumed: [{ item_id: 'wood', quantity: 2 }],
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`agent_id=${alice.agent_id}`));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('action_id=craft-chair'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cost_money=100'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('items_consumed=woodx2'));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining(`agent_id=${alice.agent_id}`));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('action_id=craft-chair'));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('cost_money=100'));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('items_consumed=woodx2'));
+    expect(reportErrorSpy).toHaveBeenCalledWith(expect.stringContaining('アクションは続行します'));
+  });
+
+  it('continues action start even when the error reporter throws', async () => {
+    let failPersist = false;
+    const onRegistrationChanged = vi.fn(() => {
+      if (failPersist) {
+        throw new Error('persist failed');
+      }
+    });
+    const onError = vi.fn(() => {
+      throw new Error('report failed');
+    });
+    const { engine } = createTestWorld({
+      config: {
+        economy: { initial_money: 1000 },
+        map: {
+          ...createTestWorld().config.map,
+          buildings: [
+            {
+              building_id: 'building-workshop',
+              name: 'Workshop',
+              description: 'A workshop.',
+              wall_nodes: ['1-3', '1-4', '1-5', '2-3', '2-5'],
+              interior_nodes: ['2-4'],
+              door_nodes: ['3-4'],
+              actions: [
+                {
+                  action_id: 'craft-chair',
+                  name: 'Craft chair',
+                  description: 'Build a chair.',
+                  duration_ms: 1000,
+                  cost_money: 100,
+                  required_items: [{ item_id: 'wood', quantity: 2 }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      engineOptions: { onRegistrationChanged, onError },
+    });
+    const alice = await createLoggedInAgent(engine);
+    engine.state.setNode(alice.agent_id, '2-4');
+    engine.state.setItems(alice.agent_id, [{ item_id: 'wood', quantity: 3 }]);
+    const reportErrorSpy = vi.spyOn(engine, 'reportError');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const events: WorldEvent[] = [];
+    engine.eventBus.onAny((event) => events.push(event));
+
+    failPersist = true;
+    let response!: ReturnType<typeof engine.executeAction>;
+    expect(() => {
+      response = engine.executeAction(alice.agent_id, { action_id: 'craft-chair' });
+    }).not.toThrow();
+
+    expect(response.ok).toBe(true);
+    expect(engine.state.getLoggedIn(alice.agent_id)?.state).toBe('in_action');
+    expect(engine.timerManager.find((timer) => timer.type === 'action' && timer.agent_id === alice.agent_id)).toBeDefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'action_started',
+        agent_id: alice.agent_id,
+        action_id: 'craft-chair',
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalled();
+    expect(reportErrorSpy).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.stringContaining('アクションは続行します'));
+    expect(errorSpy).toHaveBeenCalledWith('World error reporter threw.', expect.any(Error));
+  });
+
   it('shows actions with required_items even when the agent does not hold them', async () => {
     const { engine } = createTestWorld({
       config: {


### PR DESCRIPTION
## Summary

- Issue #73 の修正。`executeValidatedAction` で `cost_money` / `required_items` をメモリ反映した直後に `persistLoggedInAgentState()` が throw すると、以降の state 遷移 / action timer 生成 / `action_started` emit がすべて未実行になる silent failure を塞ぐ
- 実装前後で 5 つのレビュー（`silent-failure-hunter` / `pr-test-analyzer` / `pr-review-toolkit:code-reviewer` / `feature-dev:code-reviewer` / Codex CLI）を通して設計を確定。詳細は Issue #73 本文

## Changes

### 1. `apps/server/src/domain/actions.ts`

`executeValidatedAction` の `persistLoggedInAgentState()` 呼び出しを try/catch でラップ。失敗時は `console.warn` + `engine.reportError` に `agent_id` / `action_id` / `cost_money` / `items_consumed` を含むサマリを出して、state 遷移 / timer 作成 / `action_started` emit を継続。

`handleActionCompleted` (actions.ts:391-400) / `handleItemUseCompleted` (use-item.ts:150-157) と同じ try/catch パターン。catch の範囲は `persistLoggedInAgentState()` のみで、後続の timer 作成 / `emitEvent` は catch の外（core runtime 失敗は握りつぶさない設計）。

### 2. `apps/server/src/engine/world-engine.ts`

`WorldEngine.reportError` を try/catch で保護し no-throw 化。`onError` が Discord API エラー等で throw しても呼び出し元を巻き込まないようにする。既存先例 `handleEventSideEffectError` (L714-722) と完全に同じパターン。

レビュー段階で「catch 内の `engine.reportError` 自体が throw すると Issue #73 の症状が再発する」という CRITICAL 指摘があり、その対処。既存の `handleActionCompleted` / `handleItemUseCompleted` / 本件の catch 内 `reportError` がまとめて守られる。

### 3. `apps/server/test/unit/domain/actions.test.ts`

追加テスト 2 件:
1. `continues action start when action persistence fails`: persist だけ失敗させ、`ok: true` / `in_action` / money/items 消費 / action timer / `action_started` emit / warn / `reportError` 内容を検証。さらに **`engine.state.getById` で registration は古い値のまま**（persist 失敗で永続化されていない）ことも pin して、乖離仕様を固定化
2. `continues action start even when the error reporter throws`: persist と `onError` の両方を失敗させ、それでも action start が完了する（`.not.toThrow()`）ことと `reportError` が正確に 1 回呼ばれること、`onError` が 1 回呼ばれること、`console.error('World error reporter threw.', ...)` が出ることを検証

## Test plan

- [x] `npm test -w @karakuri-world/server` → 372/372 green（本件追加 2 件含む）
- [x] `npm run typecheck` → server / front 両方 pass
- [ ] 手動確認（任意）: `apps/server/data/agents.json` を一時的に読み取り専用にして `writeFileSync` を失敗させ、cost_money 付きアクションを叩く
  - HTTP が 200 `{ ok: true }` を返し、`#world-log` に「エージェント状態の保存に失敗しました...アクションは続行します」通知が出ることを確認
  - `#{agent_channel}` に `action_started` が届き、duration 経過後に `action_completed` が続くことを確認
- [ ] 手動確認（任意）: Discord webhook を一時的に無効化（`DISCORD_TOKEN` 不正値等）して `onError` を throw させても、アクションは `in_action` に遷移し `action_started` が emit されることを確認

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)