### PR TITLE
fix: remove broken DO warm-up from deploy script

### DIFF
--- a/apps/front/README.ja.md
+++ b/apps/front/README.ja.md
@@ -62,7 +62,7 @@ npx wrangler secret put SNAPSHOT_PUBLISH_AUTH_KEY
 
 `SNAPSHOT_PUBLISH_AUTH_KEY` は本体サーバー（`@karakuri-world/server`）が `/api/publish-snapshot` / `/api/publish-agent-history` を叩くときに使う共有 Bearer トークン。本体側 `.env` の同名変数と完全一致させる。空文字・空白のみは Worker 起動時の env parse で失敗するので不可。未設定なら publish endpoint は default-deny の `503` のままとなる。
 
-対話式デバッグフロー（`npm run debug:start`）でも、本体サーバーで使っている値と同じ共有キー `SNAPSHOT_PUBLISH_AUTH_KEY` を入力する。
+対話式デバッグフロー（`npm run debug:start`）でも同じ secret を入力する。
 
 ### 4. R2 バケットの CORS を設定
 
@@ -98,9 +98,8 @@ npm run deploy:prod
 
 1. `wrangler.toml` にプレースホルダ R2 バケット名が残っていたら fail-closed で停止
 2. `npx wrangler deploy` でデプロイ
-3. Worker URL に対して 1 回 `curl` を打ち、`UIBridgeDurableObject.boot()` を即時起動して静穏期 alarm 経路を立ち上げる
 
-> **注意**: 3 のウォームアップが成功しないと静穏期 fallback resync が始まらない。
+デプロイ後のウォームアップリクエストは不要。relay Durable Object は、backend から最初の認証済み `POST /api/publish-snapshot` または `POST /api/publish-agent-history` が届いた時点で自動的に起動する。
 
 ### 6. フロントエンドをデプロイ（Cloudflare Pages）
 

--- a/apps/front/README.md
+++ b/apps/front/README.md
@@ -64,7 +64,7 @@ npx wrangler secret put SNAPSHOT_PUBLISH_AUTH_KEY
 
 `SNAPSHOT_PUBLISH_AUTH_KEY` is the shared Bearer token the backend (`@karakuri-world/server`) uses when calling `/api/publish-snapshot` and `/api/publish-agent-history`. It must match the same-named variable in the backend `.env` exactly. Empty or whitespace-only values fail the Worker env parse at boot; leaving it unset keeps those publish endpoints in the default-deny `503` state.
 
-The interactive debug flow (`npm run debug:start`) prompts for the same `SNAPSHOT_PUBLISH_AUTH_KEY` value that your backend uses.
+The interactive debug flow (`npm run debug:start`) prompts for the same secret.
 
 ### 4. Configure R2 bucket CORS
 
@@ -100,9 +100,8 @@ npm run deploy:prod
 
 1. Fail closed if `wrangler.toml` still contains placeholder R2 bucket names
 2. Run `npx wrangler deploy`
-3. `curl` the Worker URL once so `UIBridgeDurableObject.boot()` runs immediately and starts the quiet-period alarm path
 
-> **Note**: If step 3 does not succeed, the quiet-period fallback resync will not start.
+No post-deploy warm-up request is needed. The relay Durable Object boots automatically when the backend sends the first authenticated `POST /api/publish-snapshot` or `POST /api/publish-agent-history`.
 
 ### 6. Deploy the frontend (Cloudflare Pages)
 

--- a/apps/front/scripts/deploy-prod.sh
+++ b/apps/front/scripts/deploy-prod.sh
@@ -32,23 +32,11 @@ fi
 if [ -z "$WORKER_URL" ]; then
   echo ""
   echo "Warning: Worker URL を検出できませんでした。"
-  echo "  手動で curl -i <WORKER_URL>/ を実行して DO の初回 boot をトリガしてください。"
-  exit 0
-fi
-
-# ==== Warm up Worker DO so snapshot publishing alarms start ====
-echo ""
-echo "Worker DO をウォームアップ中 ($WORKER_URL)..."
-WARMUP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$WORKER_URL/" || echo "000")
-if [ "$WARMUP_STATUS" = "204" ] || [ "$WARMUP_STATUS" = "200" ]; then
-  echo "Worker DO ウォームアップ完了 (HTTP $WARMUP_STATUS)"
-else
-  echo "Error: Worker DO ウォームアップの応答が想定外でした (HTTP $WARMUP_STATUS)"
-  echo "  DO の alarm 連鎖が起動しないまま snapshot publisher が休眠状態となるため、デプロイを失敗扱いにします。"
-  echo "  原因を解消したうえで再実行するか、手動で curl -i $WORKER_URL/ を成功させてから利用してください。"
-  exit 1
+  echo "  wrangler deploy 自体は成功しています。必要であれば Cloudflare Dashboard / wrangler の出力から URL を確認してください。"
 fi
 
 echo ""
 echo "===== Production deploy 完了 ====="
-echo "Worker: $WORKER_URL"
+if [ -n "$WORKER_URL" ]; then
+  echo "Worker: $WORKER_URL"
+fi


### PR DESCRIPTION
## Summary
- remove the broken post-deploy Durable Object warm-up from `apps/front/scripts/deploy-prod.sh`
- document that the Durable Object boots on the first authenticated publish request
- keep production deploys from failing after a successful `wrangler deploy`

## Validation
- bash -n apps/front/scripts/deploy-prod.sh
- npm test -w @karakuri-world/front -- worker/test/relay-bootstrap.test.ts worker/test/publish-endpoints.test.ts
- npm run build -w @karakuri-world/front

Closes #78
